### PR TITLE
Use key pairs

### DIFF
--- a/security/src/androidTest/java/com/twilio/security/crypto/AESGCMNoPaddingEncrypterTests.kt
+++ b/security/src/androidTest/java/com/twilio/security/crypto/AESGCMNoPaddingEncrypterTests.kt
@@ -15,7 +15,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.security.KeyStore
-import java.security.KeyStore.SecretKeyEntry
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
@@ -50,11 +49,8 @@ class AESGCMNoPaddingEncrypterTests {
     val encrypter = androidKeyManager.encrypter(template)
     assertTrue(encrypter is AESEncrypter)
     assertTrue(keyStore.containsAlias(alias))
-    assertNotNull((encrypter as? AESEncrypter)?.entry)
-    assertEquals(
-        (keyStore.getEntry(alias, null) as? SecretKeyEntry)?.secretKey,
-        (encrypter as AESEncrypter).entry.secretKey
-    )
+    assertNotNull((encrypter as? AESEncrypter)?.key)
+    assertEquals(keyStore.getKey(alias, null), (encrypter as AESEncrypter).key)
   }
 
   @Test
@@ -64,8 +60,8 @@ class AESGCMNoPaddingEncrypterTests {
     val encrypter = androidKeyManager.encrypter(template)
     assertTrue(encrypter is AESEncrypter)
     assertTrue(keyStore.containsAlias(alias))
-    assertNotNull((encrypter as? AESEncrypter)?.entry)
-    assertEquals(key, (encrypter as AESEncrypter).entry.secretKey)
+    assertNotNull((encrypter as? AESEncrypter)?.key)
+    assertEquals(key, (encrypter as AESEncrypter).key)
   }
 
   @Test

--- a/security/src/androidTest/java/com/twilio/security/crypto/ECP256SignerTests.kt
+++ b/security/src/androidTest/java/com/twilio/security/crypto/ECP256SignerTests.kt
@@ -46,12 +46,10 @@ class ECP256SignerTests {
     val signer = androidKeyManager.signer(template)
     assertTrue(signer is ECSigner)
     assertTrue(keyStore.containsAlias(alias))
-    assertNotNull((signer as? ECSigner)?.entry)
+    assertNotNull((signer as? ECSigner)?.keyPair)
     assertTrue(
-        (keyStore.getEntry(
-            alias, null
-        ) as? KeyStore.PrivateKeyEntry)?.certificate?.publicKey?.encoded?.contentEquals(
-            (signer as ECSigner).entry.certificate.publicKey.encoded
+        keyStore.getCertificate(alias)?.publicKey?.encoded?.contentEquals(
+            (signer as ECSigner).keyPair.public.encoded
         ) == true
     )
   }
@@ -63,10 +61,10 @@ class ECP256SignerTests {
     val signer = androidKeyManager.signer(template)
     assertTrue(signer is ECSigner)
     assertTrue(keyStore.containsAlias(alias))
-    assertNotNull((signer as? ECSigner)?.entry)
+    assertNotNull((signer as? ECSigner)?.keyPair)
     assertTrue(
         keyPair.public.encoded?.contentEquals(
-            (signer as ECSigner).entry.certificate.publicKey.encoded
+            (signer as ECSigner).keyPair.public.encoded
         ) == true
     )
   }

--- a/security/src/main/java/com/twilio/security/crypto/key/encrypter/AESEncrypter.kt
+++ b/security/src/main/java/com/twilio/security/crypto/key/encrypter/AESEncrypter.kt
@@ -4,12 +4,12 @@
 package com.twilio.security.crypto.key.encrypter
 
 import com.twilio.security.crypto.KeyException
-import java.security.KeyStore.SecretKeyEntry
 import java.security.spec.AlgorithmParameterSpec
 import javax.crypto.Cipher
+import javax.crypto.SecretKey
 
 class AESEncrypter(
-  internal val entry: SecretKeyEntry,
+  internal val key: SecretKey,
   private val cipherAlgorithm: String,
   private val parameterSpecClass: Class<out AlgorithmParameterSpec>
 ) : Encrypter {
@@ -17,7 +17,7 @@ class AESEncrypter(
     return try {
       Cipher.getInstance(cipherAlgorithm)
           .run {
-            init(Cipher.ENCRYPT_MODE, entry.secretKey)
+            init(Cipher.ENCRYPT_MODE, key)
             EncryptedData(parameters.getParameterSpec(parameterSpecClass), doFinal(data))
           }
     } catch (e: Exception) {
@@ -29,7 +29,7 @@ class AESEncrypter(
     return try {
       Cipher.getInstance(cipherAlgorithm)
           .run {
-            init(Cipher.DECRYPT_MODE, entry.secretKey, data.algorithmParameterSpec)
+            init(Cipher.DECRYPT_MODE, key, data.algorithmParameterSpec)
             doFinal(data.encrypted)
           }
     } catch (e: Exception) {

--- a/security/src/main/java/com/twilio/security/crypto/key/signer/ECSigner.kt
+++ b/security/src/main/java/com/twilio/security/crypto/key/signer/ECSigner.kt
@@ -4,11 +4,11 @@
 package com.twilio.security.crypto.key.signer
 
 import com.twilio.security.crypto.KeyException
-import java.security.KeyStore.PrivateKeyEntry
+import java.security.KeyPair
 import java.security.Signature
 
 class ECSigner(
-  internal val entry: PrivateKeyEntry,
+  internal val keyPair: KeyPair,
   private val signatureAlgorithm: String
 ) : Signer {
   @Throws(KeyException::class)
@@ -16,7 +16,7 @@ class ECSigner(
     return try {
       Signature.getInstance(signatureAlgorithm)
           .run {
-            initSign(entry.privateKey)
+            initSign(keyPair.private)
             update(data)
             sign()
           }
@@ -33,7 +33,7 @@ class ECSigner(
     return try {
       Signature.getInstance(signatureAlgorithm)
           .run {
-            initVerify(entry.certificate)
+            initVerify(keyPair.public)
             update(data)
             verify(signature)
           }
@@ -45,7 +45,7 @@ class ECSigner(
   @Throws(KeyException::class)
   override fun getPublic(): ByteArray {
     return try {
-      entry.certificate.publicKey.encoded
+      keyPair.public.encoded
     } catch (e: Exception) {
       throw KeyException(e)
     }

--- a/security/src/test/java/com/twilio/security/crypto/key/encrypter/AESEncrypterTest.kt
+++ b/security/src/test/java/com/twilio/security/crypto/key/encrypter/AESEncrypterTest.kt
@@ -25,9 +25,9 @@ import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.security.AlgorithmParameters
-import java.security.KeyStore
 import java.security.Provider
 import java.security.Security
+import javax.crypto.SecretKey
 import javax.crypto.spec.GCMParameterSpec
 
 @RunWith(RobolectricTestRunner::class)
@@ -62,8 +62,8 @@ class AESEncrypterTest {
     addProvider(provider)
     cipherMockInput = CipherMockInput()
     cipherMockOutput = CipherMockOutput()
-    val entry: KeyStore.SecretKeyEntry = mock()
-    AESEncrypter = AESEncrypter(entry, cipherAlgorithm, GCMParameterSpec::class.java)
+    val key: SecretKey = mock()
+    AESEncrypter = AESEncrypter(key, cipherAlgorithm, GCMParameterSpec::class.java)
   }
 
   @After
@@ -84,7 +84,7 @@ class AESEncrypterTest {
     cipherMockInput.encrypted = encrypted
     cipherMockInput.algorithmParameters = algorithmParameters
     val encryptedData = AESEncrypter.encrypt(data)
-    assertEquals(AESEncrypter.entry.secretKey, cipherMockOutput.secretKey)
+    assertEquals(AESEncrypter.key, cipherMockOutput.secretKey)
     assertTrue(cipherMockOutput.cipherInitialized)
     assertEquals(expectedEncryptedData, encryptedData)
   }
@@ -116,7 +116,7 @@ class AESEncrypterTest {
     cipherMockInput.decrypted = data
     cipherMockInput.algorithmParameters = algorithmParameters
     val decrypted = AESEncrypter.decrypt(encryptedData)
-    assertEquals(AESEncrypter.entry.secretKey, cipherMockOutput.secretKey)
+    assertEquals(AESEncrypter.key, cipherMockOutput.secretKey)
     assertTrue(cipherMockOutput.cipherInitialized)
     assertTrue(data.toByteArray().contentEquals(decrypted))
   }

--- a/security/src/test/java/com/twilio/security/crypto/mocks/keystore/KeyStoreMockInput.kt
+++ b/security/src/test/java/com/twilio/security/crypto/mocks/keystore/KeyStoreMockInput.kt
@@ -1,10 +1,8 @@
 package com.twilio.security.crypto.mocks.keystore
 
-import java.security.KeyStore
-
 data class KeyStoreMockInput(
   val containsAlias: Boolean,
-  val entry: KeyStore.Entry?,
   val key: Any?,
+  val newKey: Any? = null,
   val error: RuntimeException? = null
 )

--- a/security/src/test/java/com/twilio/security/crypto/mocks/keystore/generator/KeyGeneratorMock.kt
+++ b/security/src/test/java/com/twilio/security/crypto/mocks/keystore/generator/KeyGeneratorMock.kt
@@ -34,6 +34,6 @@ class KeyGeneratorMock : KeyGeneratorSpi() {
 
   override fun engineGenerateKey(): SecretKey? {
     keyStoreMockOutput.generatedKeyPair = true
-    return keyStoreMockInput.key as? SecretKey
+    return keyStoreMockInput.newKey as? SecretKey
   }
 }

--- a/security/src/test/java/com/twilio/security/crypto/mocks/keystore/generator/KeyPairGeneratorMock.kt
+++ b/security/src/test/java/com/twilio/security/crypto/mocks/keystore/generator/KeyPairGeneratorMock.kt
@@ -13,7 +13,7 @@ internal const val keyPairGeneratorMockName =
 class KeyPairGeneratorMock : KeyPairGeneratorSpi() {
   override fun generateKeyPair(): KeyPair? {
     keyStoreMockOutput.generatedKeyPair = true
-    return keyStoreMockInput.key as? KeyPair
+    return keyStoreMockInput.newKey as? KeyPair
   }
 
   override fun initialize(


### PR DESCRIPTION
Use key pairs instead of entries, android issue: https://stackoverflow.com/questions/52024752/android-9-keystore-exception-android-os-servicespecificexception. Getting an entry does not fail, but prints a warning

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
