### PR TITLE
[18445][18480] Access token & use only prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ See [Verify Push Quickstart](https://www.twilio.com/docs/verify/quickstarts/push
 ### To run the Sample App:
 * Clone the repo
 * Follow the steps from [Firebase configuration](#FirebaseConfiguration)
-* Get the Enrollment JWE generation URL from your backend [(Running the Sample backend)](#SampleBackend). You will use it for creating a factor
+* Get the Access Token generation URL from your backend [(Running the Sample backend)](#SampleBackend). You will use it for creating a factor
 * Run the `sample` module using `release` as build variant
 
 <a name='FirebaseConfiguration'></a>
@@ -86,14 +86,14 @@ In order to run the sample app, you have to create a project and application in 
 
 ### Adding a factor
 * Press Create factor in the factor list (main view)
-* Enter the entity identity to use. This value should be an UUID that identifies the user to prevent PII information use
-* Enter the enrollment URL (Enrollment JWE generation URL, including the path, e.g. https://yourapp.ngrok.io/enroll)
+* Enter the identity to use. This value should be an UUID that identifies the user to prevent PII information use
+* Enter the Access token URL (Access token generation URL, including the path, e.g. https://yourapp.ngrok.io/accessTokens)
 * Press Create factor
 * Copy the factor Sid
 
 ### Sending a challenge
 * Go to Create Push Challenge page (/challenge path in your sample backend)
-* Enter the entity `identity` you used in factor creation
+* Enter the `identity` you used in factor creation
 * Enter the `Factor Sid` you added
 * Enter a `message`. You will see the message in the push notification and in the challenge view
 * Enter details to the challenge. You will see them in the challenge view. You can add more details using the `Add more Details` button

--- a/diagrams/CreatePushFactor/CreatePushFactor.wsd
+++ b/diagrams/CreatePushFactor/CreatePushFactor.wsd
@@ -11,7 +11,7 @@ interface Models.Factor {
     friendlyName: String
     accountSid: String
     serviceSid: String
-    entityIdentity: String
+    identity: String
     type: FactorType
     status: FactorStatus
 }
@@ -64,7 +64,7 @@ class Domain.Factor.FactorRepository implements Domain.Factor.FactorProvider {
 
 }
 class Domain.Factor.PushFactory {
-    create(jwe: String, friendlyName: String, pushToken: String, success: (Factor)->(), error: (TwilioVerifyException)->())
+    create(accessToken: String, friendlyName: String, pushToken: String, success: (Factor)->(), error: (TwilioVerifyException)->())
     verify(sid: String, verificationCode: String, success: (Factor)->(), error: (TwilioVerifyException)->())
 }
 Domain.Factor.PushFactory o-left-> Data.KeyStorage: create key pair

--- a/diagrams/TwilioVerifyManager/TwilioVerifyManager.wsd
+++ b/diagrams/TwilioVerifyManager/TwilioVerifyManager.wsd
@@ -28,7 +28,7 @@ interface FactorInput {
 }
 class PushFactorInput implements FactorInput {
     pushToken: String
-    enrollmentJwe: String
+    accessToken: String
 }
 interface VerifyFactorInput {
     sid: String

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ pomGroup=com.twilio
 # Version
 versionMajor=0
 versionMinor=0
-versionPatch=1
+versionPatch=2

--- a/sample/src/main/java/com/twilio/verify/sample/java/TwilioVerifyJavaAdapter.java
+++ b/sample/src/main/java/com/twilio/verify/sample/java/TwilioVerifyJavaAdapter.java
@@ -14,8 +14,8 @@ import com.twilio.verify.models.VerifyFactorPayload;
 import com.twilio.verify.models.VerifyPushFactorPayload;
 import com.twilio.verify.sample.TwilioVerifyAdapter;
 import com.twilio.verify.sample.model.CreateFactorData;
-import com.twilio.verify.sample.model.EnrollmentResponse;
-import com.twilio.verify.sample.model.EnrollmentResponseKt;
+import com.twilio.verify.sample.model.AccessTokenResponse;
+import com.twilio.verify.sample.model.AccessTokenResponseKt;
 import com.twilio.verify.sample.networking.SampleBackendAPIClient;
 import com.twilio.verify.sample.networking.SampleBackendAPIClientKt;
 import com.twilio.verify.sample.push.NewChallenge;
@@ -41,9 +41,9 @@ public class TwilioVerifyJavaAdapter implements TwilioVerifyAdapter {
       @NotNull SampleBackendAPIClient sampleBackendAPIClient,
       @NotNull final Function1<? super Factor, Unit> success,
       @NotNull final Function1<? super Throwable, Unit> error) {
-    SampleBackendAPIClientKt.getEnrollmentResponse(sampleBackendAPIClient,
-        createFactorData.getIdentity(), createFactorData.getEnrollmentUrl(), enrollmentResponse -> {
-          FactorPayload factorPayload = getFactorPayload(createFactorData, enrollmentResponse);
+    SampleBackendAPIClientKt.getAccessTokenResponse(sampleBackendAPIClient,
+        createFactorData.getIdentity(), createFactorData.getAccessTokenUrl(), accessTokenResponse -> {
+          FactorPayload factorPayload = getFactorPayload(createFactorData, accessTokenResponse);
           twilioVerify.createFactor(factorPayload,
               factor -> {
                 verifyFactor(factor, success, error);
@@ -108,15 +108,15 @@ public class TwilioVerifyJavaAdapter implements TwilioVerifyAdapter {
       };
 
   private FactorPayload getFactorPayload(CreateFactorData createFactorData,
-                                         EnrollmentResponse enrollmentResponse) {
-    switch (EnrollmentResponseKt.getFactorType(enrollmentResponse)) {
+                                         AccessTokenResponse accessTokenResponse) {
+    switch (AccessTokenResponseKt.getFactorType(accessTokenResponse)) {
       case PUSH:
         return new PushFactorPayload(createFactorData.getFactorName(),
-            enrollmentResponse.getServiceSid(),
-            enrollmentResponse.getIdentity(), createFactorData.getPushToken(),
-            enrollmentResponse.getToken());
+            accessTokenResponse.getServiceSid(),
+            accessTokenResponse.getIdentity(), createFactorData.getPushToken(),
+            accessTokenResponse.getToken());
       default:
-        throw new IllegalStateException("Unexpected value: " + enrollmentResponse.getFactorType());
+        throw new IllegalStateException("Unexpected value: " + accessTokenResponse.getFactorType());
     }
   }
 

--- a/sample/src/main/java/com/twilio/verify/sample/kotlin/TwilioVerifyKotlinAdapter.kt
+++ b/sample/src/main/java/com/twilio/verify/sample/kotlin/TwilioVerifyKotlinAdapter.kt
@@ -13,10 +13,10 @@ import com.twilio.verify.models.UpdatePushFactorPayload
 import com.twilio.verify.models.VerifyPushFactorPayload
 import com.twilio.verify.sample.TwilioVerifyAdapter
 import com.twilio.verify.sample.model.CreateFactorData
-import com.twilio.verify.sample.model.EnrollmentResponse
+import com.twilio.verify.sample.model.AccessTokenResponse
 import com.twilio.verify.sample.model.getFactorType
 import com.twilio.verify.sample.networking.SampleBackendAPIClient
-import com.twilio.verify.sample.networking.getEnrollmentResponse
+import com.twilio.verify.sample.networking.getAccessTokenResponse
 import com.twilio.verify.sample.push.NewChallenge
 import com.twilio.verify.sample.push.VerifyEventBus
 
@@ -32,9 +32,9 @@ class TwilioVerifyKotlinAdapter(
     error: (Throwable) -> Unit
   ) {
     try {
-      sampleBackendAPIClient.getEnrollmentResponse(
-          createFactorData.identity, createFactorData.enrollmentUrl, { enrollmentResponse ->
-        val factorPayload = getFactorPayload(createFactorData, enrollmentResponse)
+      sampleBackendAPIClient.getAccessTokenResponse(
+          createFactorData.identity, createFactorData.accessTokenUrl, { accessTokenResponse ->
+        val factorPayload = getFactorPayload(createFactorData, accessTokenResponse)
         twilioVerify.createFactor(factorPayload, { factor ->
           verifyFactor(factor, success, error)
         }, error)
@@ -91,15 +91,15 @@ class TwilioVerifyKotlinAdapter(
   }
 
   private fun getFactorPayload(
-    createFactorData: CreateFactorData,
-    enrollmentResponse: EnrollmentResponse
+      createFactorData: CreateFactorData,
+      accessTokenResponse: AccessTokenResponse
   ): FactorPayload {
-    return when (enrollmentResponse.getFactorType()) {
+    return when (accessTokenResponse.getFactorType()) {
       PUSH -> PushFactorPayload(
-          createFactorData.factorName, enrollmentResponse.serviceSid,
-          enrollmentResponse.identity, createFactorData.pushToken, enrollmentResponse.token
+          createFactorData.factorName, accessTokenResponse.serviceSid,
+          accessTokenResponse.identity, createFactorData.pushToken, accessTokenResponse.token
       )
-      else -> throw IllegalStateException("Unexpected value: " + enrollmentResponse.factorType)
+      else -> throw IllegalStateException("Unexpected value: " + accessTokenResponse.factorType)
     }
   }
 

--- a/sample/src/main/java/com/twilio/verify/sample/model/AccessTokenResponse.kt
+++ b/sample/src/main/java/com/twilio/verify/sample/model/AccessTokenResponse.kt
@@ -6,14 +6,14 @@ import com.twilio.verify.models.FactorType
  * Copyright (c) 2020, Twilio Inc.
  */
 
-data class EnrollmentResponse(
+data class AccessTokenResponse(
   val token: String,
   val serviceSid: String,
   val identity: String,
   val factorType: String
 )
 
-fun EnrollmentResponse.getFactorType(): FactorType = FactorType.values()
+fun AccessTokenResponse.getFactorType(): FactorType = FactorType.values()
     .associateBy(FactorType::factorTypeName)[factorType] ?: throw IllegalArgumentException(
     "Invalid response"
 )

--- a/sample/src/main/java/com/twilio/verify/sample/model/CreateFactorData.kt
+++ b/sample/src/main/java/com/twilio/verify/sample/model/CreateFactorData.kt
@@ -4,5 +4,5 @@ data class CreateFactorData(
   val identity: String,
   val factorName: String,
   val pushToken: String,
-  val enrollmentUrl: String
+  val accessTokenUrl: String
 )

--- a/sample/src/main/java/com/twilio/verify/sample/networking/SampleBackendAPIClient.kt
+++ b/sample/src/main/java/com/twilio/verify/sample/networking/SampleBackendAPIClient.kt
@@ -3,7 +3,7 @@
  */
 package com.twilio.verify.sample.networking
 
-import com.twilio.verify.sample.model.EnrollmentResponse
+import com.twilio.verify.sample.model.AccessTokenResponse
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import retrofit2.Call
@@ -18,17 +18,17 @@ import java.io.IOException
 
 interface SampleBackendAPIClient {
   @POST @FormUrlEncoded
-  fun enrollment(
+  fun accessTokens(
     @Field("identity") identity: String,
     @Url url: String
-  ): Call<EnrollmentResponse>?
+  ): Call<AccessTokenResponse>?
 }
 
 @JvmOverloads fun backendAPIClient(
-  enrollmentUrl: String,
+  accessTokenUrl: String,
   okHttpClient: OkHttpClient = OkHttpClient()
 ): SampleBackendAPIClient {
-  val url = enrollmentUrl.toHttpUrl()
+  val url = accessTokenUrl.toHttpUrl()
   val retrofit = Retrofit.Builder()
       .baseUrl("${url.scheme}://${url.host}")
       .addConverterFactory(GsonConverterFactory.create())
@@ -37,27 +37,27 @@ interface SampleBackendAPIClient {
   return retrofit.create(SampleBackendAPIClient::class.java)
 }
 
-fun SampleBackendAPIClient.getEnrollmentResponse(
+fun SampleBackendAPIClient.getAccessTokenResponse(
   identity: String,
-  enrollmentUrl: String,
-  success: (EnrollmentResponse) -> Unit,
+  accessTokenUrl: String,
+  success: (AccessTokenResponse) -> Unit,
   error: (Throwable) -> Unit
 ) {
-  val call = enrollment(identity, enrollmentUrl)
-  call?.enqueue(object : retrofit2.Callback<EnrollmentResponse> {
+  val call = accessTokens(identity, accessTokenUrl)
+  call?.enqueue(object : retrofit2.Callback<AccessTokenResponse> {
     override fun onFailure(
-      call: Call<EnrollmentResponse>,
+      call: Call<AccessTokenResponse>,
       t: Throwable
     ) {
       error(t)
     }
 
     override fun onResponse(
-      call: Call<EnrollmentResponse>,
-      response: Response<EnrollmentResponse>
+      call: Call<AccessTokenResponse>,
+      response: Response<AccessTokenResponse>
     ) {
       try {
-        val enrollmentResponse =
+        val accessTokenResponse =
           response.body()
               ?.takeIf {
                 !it.token.isNullOrBlank() && !it.factorType.isNullOrBlank()
@@ -66,7 +66,7 @@ fun SampleBackendAPIClient.getEnrollmentResponse(
               response.errorBody()
                   ?.string() ?: "Invalid response"
           )
-        success(enrollmentResponse)
+        success(accessTokenResponse)
       } catch (e: Exception) {
         error(e)
       }

--- a/sample/src/main/java/com/twilio/verify/sample/view/Extensions.kt
+++ b/sample/src/main/java/com/twilio/verify/sample/view/Extensions.kt
@@ -44,5 +44,5 @@ fun Challenge.string(context: Context?) =
       )
 
 fun Factor.string() =
-  "Sid:\n${this.sid}\nEntity Identity:\n${this.entityIdentity}\nName: ${this.friendlyName}" +
+  "Sid:\n${this.sid}\nIdentity:\n${this.identity}\nName: ${this.friendlyName}" +
       "\nStatus: ${this.status}"

--- a/sample/src/main/java/com/twilio/verify/sample/view/factors/create/CreateFactorFragment.kt
+++ b/sample/src/main/java/com/twilio/verify/sample/view/factors/create/CreateFactorFragment.kt
@@ -19,9 +19,9 @@ import com.twilio.verify.sample.model.CreateFactorData
 import com.twilio.verify.sample.view.showError
 import com.twilio.verify.sample.viewmodel.FactorError
 import com.twilio.verify.sample.viewmodel.FactorViewModel
+import kotlinx.android.synthetic.main.fragment_create_factor.accessTokenUrlInput
 import kotlinx.android.synthetic.main.fragment_create_factor.content
 import kotlinx.android.synthetic.main.fragment_create_factor.createFactor
-import kotlinx.android.synthetic.main.fragment_create_factor.enrollmentUrlInput
 import kotlinx.android.synthetic.main.fragment_create_factor.identityInput
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -74,28 +74,28 @@ class CreateFactorFragment : Fragment() {
       !this::token.isInitialized ->
         IllegalArgumentException("Invalid push token").showError(content)
       identityInput.text.toString()
-          .isEmpty() -> IllegalArgumentException("Invalid entity identity").showError(
+          .isEmpty() -> IllegalArgumentException("Invalid identity").showError(
           content
       )
-      enrollmentUrlInput.text.toString()
-          .isEmpty() || enrollmentUrlInput.text.toString()
+      accessTokenUrlInput.text.toString()
+          .isEmpty() || accessTokenUrlInput.text.toString()
           .toHttpUrlOrNull() == null -> IllegalArgumentException(
-          "Invalid enrollment url"
+          "Invalid access token url"
       ).showError(
           content
       )
       else -> {
-        createFactor(identityInput.text.toString(), enrollmentUrlInput.text.toString())
+        createFactor(identityInput.text.toString(), accessTokenUrlInput.text.toString())
       }
     }
   }
 
   private fun createFactor(
     identity: String,
-    enrollmentUrl: String
+    accessTokenUrl: String
   ) {
     createFactor.isEnabled = false
-    val createFactorData = CreateFactorData(identity, "$identity's factor", token, enrollmentUrl)
+    val createFactorData = CreateFactorData(identity, "$identity's factor", token, accessTokenUrl)
     factorViewModel.createFactor(createFactorData)
   }
 

--- a/sample/src/main/java/com/twilio/verify/sample/viewmodel/FactorViewModel.kt
+++ b/sample/src/main/java/com/twilio/verify/sample/viewmodel/FactorViewModel.kt
@@ -29,7 +29,7 @@ class FactorViewModel(private val twilioVerifyAdapter: TwilioVerifyAdapter) : Vi
 
   fun createFactor(createFactorData: CreateFactorData) {
     twilioVerifyAdapter.createFactor(
-        createFactorData, backendAPIClient(createFactorData.enrollmentUrl), {
+        createFactorData, backendAPIClient(createFactorData.accessTokenUrl), {
       factor.value = Factor(it)
     }, {
       factor.value = FactorError(it)

--- a/sample/src/main/res/layout/fragment_create_factor.xml
+++ b/sample/src/main/res/layout/fragment_create_factor.xml
@@ -29,14 +29,14 @@
   </com.google.android.material.textfield.TextInputLayout>
 
   <com.google.android.material.textfield.TextInputLayout
-      android:id="@+id/enrollmentUrlLayout"
+      android:id="@+id/accessTokenUrlLayout"
       style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_marginStart="8dp"
       android:layout_marginTop="16dp"
       android:layout_marginEnd="8dp"
-      android:hint="@string/enrollment_url"
+      android:hint="@string/access_token_url"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintHorizontal_bias="0.5"
       app:layout_constraintStart_toStartOf="parent"
@@ -44,7 +44,7 @@
       >
 
     <com.google.android.material.textfield.TextInputEditText
-        android:id="@+id/enrollmentUrlInput"
+        android:id="@+id/accessTokenUrlInput"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         />
@@ -59,6 +59,6 @@
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintHorizontal_bias="0.5"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@+id/enrollmentUrlLayout"
+      app:layout_constraintTop_toBottomOf="@+id/accessTokenUrlLayout"
       />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -9,6 +9,6 @@
   <string name="new_challenge">New challenge</string>
   <string name="channel_name">@string/challenges</string>
   <string name="channel_description">Receive challenges</string>
-  <string name="enrollment_url">Enrollment URL</string>
-  <string name="identity">Entity identity</string>
+  <string name="access_token_url">Access token URL</string>
+  <string name="identity">Identity</string>
 </resources>

--- a/sample/src/test/java/com/twilio/verify/sample/kotlin/TwilioVerifyKotlinAdapterTest.kt
+++ b/sample/src/test/java/com/twilio/verify/sample/kotlin/TwilioVerifyKotlinAdapterTest.kt
@@ -20,7 +20,7 @@ import com.twilio.verify.models.VerifyPushFactorPayload
 import com.twilio.verify.sample.IdlingResource
 import com.twilio.verify.sample.TwilioVerifyAdapter
 import com.twilio.verify.sample.model.CreateFactorData
-import com.twilio.verify.sample.model.EnrollmentResponse
+import com.twilio.verify.sample.model.AccessTokenResponse
 import com.twilio.verify.sample.networking.SampleBackendAPIClient
 import com.twilio.verify.sample.push.NewChallenge
 import com.twilio.verify.sample.push.VerifyEventBus
@@ -54,15 +54,15 @@ class TwilioVerifyKotlinAdapterTest {
   }
 
   @Test
-  fun `Create factor with invalid JWE should return exception`() {
+  fun `Create factor with invalid access token should return exception`() {
     val expectedException: RuntimeException = mock()
     val createFactorData = CreateFactorData("identity", "factorName", "pushToken", "url")
-    val mockCall: Call<EnrollmentResponse> = mock {
-      argumentCaptor<(Callback<EnrollmentResponse>)>().apply {
+    val mockCall: Call<AccessTokenResponse> = mock {
+      argumentCaptor<(Callback<AccessTokenResponse>)>().apply {
         on { enqueue(capture()) }.thenThrow(expectedException)
       }
     }
-    whenever(sampleBackendAPIClient.enrollment(eq(createFactorData.identity), any())).thenReturn(
+    whenever(sampleBackendAPIClient.accessTokens(eq(createFactorData.identity), any())).thenReturn(
         mockCall
     )
     idlingResource.startOperation()
@@ -80,18 +80,18 @@ class TwilioVerifyKotlinAdapterTest {
   fun `Create factor with an error should return exception`() {
     val expectedException: TwilioVerifyException = mock()
     val createFactorData = CreateFactorData("identity", "factorName", "pushToken", "url")
-    val mockCall: Call<EnrollmentResponse> = mock { mockCall ->
-      argumentCaptor<(Callback<EnrollmentResponse>)>().apply {
+    val mockCall: Call<AccessTokenResponse> = mock { mockCall ->
+      argumentCaptor<(Callback<AccessTokenResponse>)>().apply {
         on { enqueue(capture()) }.then {
           firstValue.onResponse(
               mockCall, Response.success(
-              EnrollmentResponse("jwe", "serviceSid", "identity", PUSH.factorTypeName)
+              AccessTokenResponse("accessToken", "serviceSid", "identity", PUSH.factorTypeName)
           )
           )
         }
       }
     }
-    whenever(sampleBackendAPIClient.enrollment(eq(createFactorData.identity), any())).thenReturn(
+    whenever(sampleBackendAPIClient.accessTokens(eq(createFactorData.identity), any())).thenReturn(
         mockCall
     )
     argumentCaptor<(Exception) -> Unit>().apply {
@@ -111,24 +111,24 @@ class TwilioVerifyKotlinAdapterTest {
   }
 
   @Test
-  fun `Create factor with valid JWE and Push type should return factor verified`() {
+  fun `Create factor with valid access token and Push type should return factor verified`() {
     val expectedFactor: Factor = mock() {
       on { type } doReturn PUSH
       on { sid } doReturn "factorSid"
     }
     val createFactorData = CreateFactorData("identity", "factorName", "pushToken", "url")
-    val mockCall: Call<EnrollmentResponse> = mock { mockCall ->
-      argumentCaptor<(Callback<EnrollmentResponse>)>().apply {
+    val mockCall: Call<AccessTokenResponse> = mock { mockCall ->
+      argumentCaptor<(Callback<AccessTokenResponse>)>().apply {
         on { enqueue(capture()) }.then {
           firstValue.onResponse(
               mockCall, Response.success(
-              EnrollmentResponse("jwe", "serviceSid", "identity", PUSH.factorTypeName)
+              AccessTokenResponse("accessToken", "serviceSid", "identity", PUSH.factorTypeName)
           )
           )
         }
       }
     }
-    whenever(sampleBackendAPIClient.enrollment(eq(createFactorData.identity), any())).thenReturn(
+    whenever(sampleBackendAPIClient.accessTokens(eq(createFactorData.identity), any())).thenReturn(
         mockCall
     )
     argumentCaptor<(Factor) -> Unit>().apply {

--- a/sample/src/test/java/com/twilio/verify/sample/networking/SampleBackendAPIClientTest.kt
+++ b/sample/src/test/java/com/twilio/verify/sample/networking/SampleBackendAPIClientTest.kt
@@ -27,15 +27,15 @@ class SampleBackendAPIClientTest {
   fun before() {
     mockWebServer = MockWebServer()
     mockWebServer.start()
-    url = mockWebServer.url("/enroll")
+    url = mockWebServer.url("/accessTokens")
         .toString()
     sampleBackendAPIClient = backendAPIClient(url)
   }
 
   @Test
-  fun `Enrollment with success response should return enrollment response`() {
+  fun `Access token with success response should return access token response`() {
     val identity = "identity"
-    val tokenValue = "jweToken"
+    val tokenValue = "accessToken"
     val serviceSidValue = "serviceSidValue"
     val factorTypeValue = "push"
     val identityValue = "identityValue"
@@ -49,11 +49,11 @@ class SampleBackendAPIClientTest {
         .setBody(bodyJson.toString())
     mockWebServer.enqueue(mockResponse)
     idlingResource.startOperation()
-    sampleBackendAPIClient.getEnrollmentResponse(identity, url, { enrollmentResponse ->
-      assertEquals(tokenValue, enrollmentResponse.token)
-      assertEquals(serviceSidValue, enrollmentResponse.serviceSid)
-      assertEquals(factorTypeValue, enrollmentResponse.factorType)
-      assertEquals(identityValue, enrollmentResponse.identity)
+    sampleBackendAPIClient.getAccessTokenResponse(identity, url, { accessTokenResponse ->
+      assertEquals(tokenValue, accessTokenResponse.token)
+      assertEquals(serviceSidValue, accessTokenResponse.serviceSid)
+      assertEquals(factorTypeValue, accessTokenResponse.factorType)
+      assertEquals(identityValue, accessTokenResponse.identity)
       idlingResource.operationFinished()
     }, {
       fail()
@@ -63,7 +63,7 @@ class SampleBackendAPIClientTest {
   }
 
   @Test
-  fun `Enrollment with success response but with invalid response code should return throw exception`() {
+  fun `Access token with success response but with invalid response code should return throw exception`() {
     val identity = "identity"
     val bodyJson = JSONObject().apply {
       put("field", "value")
@@ -72,7 +72,7 @@ class SampleBackendAPIClientTest {
         .setBody(bodyJson.toString())
     mockWebServer.enqueue(mockResponse)
     idlingResource.startOperation()
-    sampleBackendAPIClient.getEnrollmentResponse(identity, url, {
+    sampleBackendAPIClient.getAccessTokenResponse(identity, url, {
       fail()
       idlingResource.operationFinished()
     }, { exception ->
@@ -83,7 +83,7 @@ class SampleBackendAPIClientTest {
   }
 
   @Test
-  fun `Enrollment with error response should return throw exception`() {
+  fun `Access token with error response should return throw exception`() {
     val identity = "identity"
     val bodyJson = JSONObject().apply {
       put("error", "25000")
@@ -93,7 +93,7 @@ class SampleBackendAPIClientTest {
         .setBody(bodyJson.toString())
     mockWebServer.enqueue(mockResponse)
     idlingResource.startOperation()
-    sampleBackendAPIClient.getEnrollmentResponse(identity, url, {
+    sampleBackendAPIClient.getAccessTokenResponse(identity, url, {
       fail()
       idlingResource.operationFinished()
     }, { exception ->

--- a/verify/build.gradle
+++ b/verify/build.gradle
@@ -13,20 +13,13 @@ android {
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles 'consumer-rules.pro'
+    buildConfigField "String", 'BASE_URL', "\"https://verify.twilio.com/v2/\""
   }
 
   buildTypes {
     release {
       minifyEnabled false
-      buildConfigField "String", 'BASE_URL', "\"https://verify.twilio.com/v2/\""
       proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-    }
-    debug {
-      buildConfigField "String", 'BASE_URL', "\"https://verify.stage.twilio.com/v2/\""
-    }
-    dev {
-      buildConfigField "String", 'BASE_URL', "\"https://verify.dev.twilio.com/v2/\""
-      matchingFallbacks = ['debug']
     }
   }
   testOptions.unitTests.includeAndroidResources = true

--- a/verify/src/androidTest/java/com/twilio/verify/BaseFactorTest.kt
+++ b/verify/src/androidTest/java/com/twilio/verify/BaseFactorTest.kt
@@ -31,7 +31,7 @@ open class BaseFactorTest : BaseServerTest() {
 
   protected fun createFactor(onSuccess: (Factor) -> Unit = {}) {
     val friendlyName = "friendlyName"
-    val jwe = "eyJjdHkiOiJ0d2lsaW8tZnBhO3Y9MSIsInR5cCI6IkpXVCIsImFsZyI6IkhTMjU2In0.eyJpc3MiOiJTSz" +
+    val accessToken = "eyJjdHkiOiJ0d2lsaW8tZnBhO3Y9MSIsInR5cCI6IkpXVCIsImFsZyI6IkhTMjU2In0.eyJpc3MiOiJTSz" +
         "AwMTBjZDc5Yzk4NzM1ZTBjZDliYjQ5NjBlZjYyZmI4IiwiZXhwIjoxNTgzOTM3NjY0LCJncmFudHMiOnsidmVyaW" +
         "Z5Ijp7ImlkZW50aXR5IjoiWUViZDE1NjUzZDExNDg5YjI3YzFiNjI1NTIzMDMwMTgxNSIsImZhY3RvciI6InB1c2" +
         "giLCJyZXF1aXJlLWJpb21ldHJpY3MiOnRydWV9LCJhcGkiOnsiYXV0aHlfdjEiOlt7ImFjdCI6WyJjcmVhdGUiXS" +
@@ -40,7 +40,7 @@ open class BaseFactorTest : BaseServerTest() {
         "VlMGNkOWJiNDk2MGVmNjJmYjgtMTU4Mzg1MTI2NCIsInN1YiI6IkFDYzg1NjNkYWY4OGVkMjZmMjI3NjM4ZjU3Mz" +
         "g3MjZmYmQifQ.R01YC9mfCzIf9W81GUUCMjTwnhzIIqxV-tcdJYuy6kA"
     val factorPayload =
-      PushFactorPayload(friendlyName, "serviceSid", "identity", "pushToken", jwe)
+      PushFactorPayload(friendlyName, "serviceSid", "identity", "pushToken", accessToken)
     enqueueMockResponse(200, APIResponses.createValidFactorResponse())
     idlingResource.increment()
     twilioVerify.createFactor(factorPayload, {

--- a/verify/src/androidTest/java/com/twilio/verify/CreateFactorTests.kt
+++ b/verify/src/androidTest/java/com/twilio/verify/CreateFactorTests.kt
@@ -36,9 +36,9 @@ class CreateFactorTests : BaseServerTest() {
   }
 
   @Test
-  fun testCreateFactorWithValidJWEAndValidAPIResponseShouldReturnFactor() {
+  fun testCreateFactorWithValidAccessTokenAndValidAPIResponseShouldReturnFactor() {
     val friendlyName = "friendlyName"
-    val jwe = "eyJjdHkiOiJ0d2lsaW8tZnBhO3Y9MSIsInR5cCI6IkpXVCIsImFsZyI6IkhTMjU2In0.eyJpc3MiOiJTSz" +
+    val accessToken = "eyJjdHkiOiJ0d2lsaW8tZnBhO3Y9MSIsInR5cCI6IkpXVCIsImFsZyI6IkhTMjU2In0.eyJpc3MiOiJTSz" +
         "AwMTBjZDc5Yzk4NzM1ZTBjZDliYjQ5NjBlZjYyZmI4IiwiZXhwIjoxNTgzOTM3NjY0LCJncmFudHMiOnsidmVyaW" +
         "Z5Ijp7ImlkZW50aXR5IjoiWUViZDE1NjUzZDExNDg5YjI3YzFiNjI1NTIzMDMwMTgxNSIsImZhY3RvciI6InB1c2" +
         "giLCJyZXF1aXJlLWJpb21ldHJpY3MiOnRydWV9LCJhcGkiOnsiYXV0aHlfdjEiOlt7ImFjdCI6WyJjcmVhdGUiXS" +
@@ -47,7 +47,7 @@ class CreateFactorTests : BaseServerTest() {
         "VlMGNkOWJiNDk2MGVmNjJmYjgtMTU4Mzg1MTI2NCIsInN1YiI6IkFDYzg1NjNkYWY4OGVkMjZmMjI3NjM4ZjU3Mz" +
         "g3MjZmYmQifQ.R01YC9mfCzIf9W81GUUCMjTwnhzIIqxV-tcdJYuy6kA"
     val factorPayload =
-      PushFactorPayload(friendlyName, "serviceSid", "identity", "pushToken", jwe)
+      PushFactorPayload(friendlyName, "serviceSid", "identity", "pushToken", accessToken)
     enqueueMockResponse(200, APIResponses.createValidFactorResponse())
     idlingResource.increment()
     twilioVerify.createFactor(factorPayload, {
@@ -73,7 +73,7 @@ class CreateFactorTests : BaseServerTest() {
     assertEquals(factor.type, storedFactor.type)
     assertEquals(factor.friendlyName, storedFactor.friendlyName)
     assertEquals(factor.status, storedFactor.status)
-    assertEquals(factor.entityIdentity, storedFactor.entityIdentity)
+    assertEquals(factor.identity, storedFactor.identity)
     assertEquals(factor.accountSid, storedFactor.accountSid)
     assertEquals(factor.serviceSid, storedFactor.serviceSid)
   }
@@ -91,9 +91,9 @@ class CreateFactorTests : BaseServerTest() {
   }
 
   @Test
-  fun testCreateFactorWithValidJWEAndInvalidAPIResponseCodeShouldThrowNetworkError() {
+  fun testCreateFactorWithValidAccessTokenAndInvalidAPIResponseCodeShouldThrowNetworkError() {
     val friendlyName = "friendlyName"
-    val jwe = "eyJjdHkiOiJ0d2lsaW8tZnBhO3Y9MSIsInR5cCI6IkpXVCIsImFsZyI6IkhTMjU2In0.eyJpc3MiOiJTSz" +
+    val accessToken = "eyJjdHkiOiJ0d2lsaW8tZnBhO3Y9MSIsInR5cCI6IkpXVCIsImFsZyI6IkhTMjU2In0.eyJpc3MiOiJTSz" +
         "AwMTBjZDc5Yzk4NzM1ZTBjZDliYjQ5NjBlZjYyZmI4IiwiZXhwIjoxNTgzOTM3NjY0LCJncmFudHMiOnsidmVyaW" +
         "Z5Ijp7ImlkZW50aXR5IjoiWUViZDE1NjUzZDExNDg5YjI3YzFiNjI1NTIzMDMwMTgxNSIsImZhY3RvciI6InB1c2" +
         "giLCJyZXF1aXJlLWJpb21ldHJpY3MiOnRydWV9LCJhcGkiOnsiYXV0aHlfdjEiOlt7ImFjdCI6WyJjcmVhdGUiXS" +
@@ -102,7 +102,7 @@ class CreateFactorTests : BaseServerTest() {
         "VlMGNkOWJiNDk2MGVmNjJmYjgtMTU4Mzg1MTI2NCIsInN1YiI6IkFDYzg1NjNkYWY4OGVkMjZmMjI3NjM4ZjU3Mz" +
         "g3MjZmYmQifQ.R01YC9mfCzIf9W81GUUCMjTwnhzIIqxV-tcdJYuy6kA"
     val factorPayload =
-      PushFactorPayload(friendlyName, "serviceSid", "identity", "pushToken", jwe)
+      PushFactorPayload(friendlyName, "serviceSid", "identity", "pushToken", accessToken)
     val expectedException = TwilioVerifyException(
         NetworkException(null, null, null),
         NetworkError
@@ -121,9 +121,9 @@ class CreateFactorTests : BaseServerTest() {
   }
 
   @Test
-  fun testCreateFactorWithValidJWEAndInvalidAPIResponseBodyShouldThrowMapperError() {
+  fun testCreateFactorWithValidAccessTokenAndInvalidAPIResponseBodyShouldThrowMapperError() {
     val friendlyName = "friendlyName"
-    val jwe = "eyJjdHkiOiJ0d2lsaW8tZnBhO3Y9MSIsInR5cCI6IkpXVCIsImFsZyI6IkhTMjU2In0.eyJpc3MiOiJTSz" +
+    val accessToken = "eyJjdHkiOiJ0d2lsaW8tZnBhO3Y9MSIsInR5cCI6IkpXVCIsImFsZyI6IkhTMjU2In0.eyJpc3MiOiJTSz" +
         "AwMTBjZDc5Yzk4NzM1ZTBjZDliYjQ5NjBlZjYyZmI4IiwiZXhwIjoxNTgzOTM3NjY0LCJncmFudHMiOnsidmVyaW" +
         "Z5Ijp7ImlkZW50aXR5IjoiWUViZDE1NjUzZDExNDg5YjI3YzFiNjI1NTIzMDMwMTgxNSIsImZhY3RvciI6InB1c2" +
         "giLCJyZXF1aXJlLWJpb21ldHJpY3MiOnRydWV9LCJhcGkiOnsiYXV0aHlfdjEiOlt7ImFjdCI6WyJjcmVhdGUiXS" +
@@ -132,7 +132,7 @@ class CreateFactorTests : BaseServerTest() {
         "VlMGNkOWJiNDk2MGVmNjJmYjgtMTU4Mzg1MTI2NCIsInN1YiI6IkFDYzg1NjNkYWY4OGVkMjZmMjI3NjM4ZjU3Mz" +
         "g3MjZmYmQifQ.R01YC9mfCzIf9W81GUUCMjTwnhzIIqxV-tcdJYuy6kA"
     val factorPayload =
-      PushFactorPayload(friendlyName, "serviceSid", "identity", "pushToken", jwe)
+      PushFactorPayload(friendlyName, "serviceSid", "identity", "pushToken", accessToken)
     val expectedException = TwilioVerifyException(
         IllegalArgumentException(null, null),
         MapperError

--- a/verify/src/main/java/com/twilio/verify/api/ChallengeAPIClient.kt
+++ b/verify/src/main/java/com/twilio/verify/api/ChallengeAPIClient.kt
@@ -165,10 +165,10 @@ internal class ChallengeAPIClient(
   private fun updateChallengeURL(challenge: FactorChallenge) =
     challenge.factor?.let { factor ->
       "$baseUrl$updateChallengeURL".replace(SERVICE_SID_PATH, factor.serviceSid, true)
-          .replace(IDENTITY_PATH, factor.entityIdentity)
+          .replace(IDENTITY_PATH, factor.identity)
           .replace(challengeSidPath, challenge.sid)
     } ?: run {
-      throw IllegalArgumentException("ServiceSid or EntityIdentity is null or empty")
+      throw IllegalArgumentException("ServiceSid or Identity is null or empty")
     }
 
   private fun updateChallengeBody(
@@ -182,12 +182,12 @@ internal class ChallengeAPIClient(
     challengeSid: String,
     factor: Factor
   ) = "$baseUrl$getChallengeURL".replace(SERVICE_SID_PATH, factor.serviceSid, true)
-      .replace(IDENTITY_PATH, factor.entityIdentity)
+      .replace(IDENTITY_PATH, factor.identity)
       .replace(challengeSidPath, challengeSid)
 
   private fun getChallengesURL(
     factor: Factor
   ) = "$baseUrl$getChallengesURL".replace(SERVICE_SID_PATH, factor.serviceSid, true)
-      .replace(IDENTITY_PATH, factor.entityIdentity)
+      .replace(IDENTITY_PATH, factor.identity)
 }
 

--- a/verify/src/main/java/com/twilio/verify/api/FactorAPIClient.kt
+++ b/verify/src/main/java/com/twilio/verify/api/FactorAPIClient.kt
@@ -56,7 +56,7 @@ internal class FactorAPIClient(
       val requestHelper =
         RequestHelper(
             context,
-            BasicAuthorization(AUTHENTICATION_USER, createFactorPayload.jwe)
+            BasicAuthorization(AUTHENTICATION_USER, createFactorPayload.accessToken)
         )
       val request = Request.Builder(
           requestHelper,
@@ -174,23 +174,23 @@ internal class FactorAPIClient(
 
   private fun createFactorURL(createFactorPayload: CreateFactorPayload): String =
     "$baseUrl$CREATE_FACTOR_URL".replace(SERVICE_SID_PATH, createFactorPayload.serviceSid, true)
-        .replace(IDENTITY_PATH, createFactorPayload.entity)
+        .replace(IDENTITY_PATH, createFactorPayload.identity)
 
   private fun verifyFactorURL(factor: Factor): String =
     "$baseUrl$VERIFY_FACTOR_URL".replace(SERVICE_SID_PATH, factor.serviceSid, true)
-        .replace(IDENTITY_PATH, factor.entityIdentity)
+        .replace(IDENTITY_PATH, factor.identity)
         .replace(FACTOR_SID_PATH, factor.sid)
 
   private fun deleteFactorURL(factor: Factor): String =
     "$baseUrl$DELETE_FACTOR_URL".replace(SERVICE_SID_PATH, factor.serviceSid, true)
-        .replace(IDENTITY_PATH, factor.entityIdentity)
+        .replace(IDENTITY_PATH, factor.identity)
         .replace(FACTOR_SID_PATH, factor.sid)
 
   private fun updateFactorURL(
     factor: Factor
   ): String =
     "$baseUrl$UPDATE_FACTOR_URL".replace(SERVICE_SID_PATH, factor.serviceSid, true)
-        .replace(IDENTITY_PATH, factor.entityIdentity)
+        .replace(IDENTITY_PATH, factor.identity)
         .replace(
             FACTOR_SID_PATH, factor.sid
         )

--- a/verify/src/main/java/com/twilio/verify/domain/factor/FactorFacade.kt
+++ b/verify/src/main/java/com/twilio/verify/domain/factor/FactorFacade.kt
@@ -36,7 +36,7 @@ internal class FactorFacade(
       when (factorPayload) {
         is PushFactorPayload -> {
           pushFactory.create(
-              factorPayload.enrollmentJwe, factorPayload.friendlyName, factorPayload.pushToken,
+              factorPayload.accessToken, factorPayload.friendlyName, factorPayload.pushToken,
               factorPayload.serviceSid, factorPayload.identity, onSuccess, onError
           )
         }

--- a/verify/src/main/java/com/twilio/verify/domain/factor/FactorMapper.kt
+++ b/verify/src/main/java/com/twilio/verify/domain/factor/FactorMapper.kt
@@ -25,7 +25,7 @@ internal const val credentialSidKey = "credential_sid"
 internal const val friendlyNameKey = "friendly_name"
 internal const val accountSidKey = "account_sid"
 internal const val serviceSidKey = "service_sid"
-internal const val entityIdentityKey = "entity_identity"
+internal const val identity = "entity_identity"
 internal const val keyPairAliasKey = "key_pair"
 internal const val dateCreatedKey = "date_created"
 
@@ -37,14 +37,14 @@ internal class FactorMapper {
     factorPayload: FactorDataPayload
   ): Factor {
     val serviceSid = factorPayload.serviceSid
-    val entityIdentity = factorPayload.entity
-    if (serviceSid.isEmpty() || entityIdentity.isEmpty()) {
+    val identity = factorPayload.identity
+    if (serviceSid.isEmpty() || identity.isEmpty()) {
       throw TwilioVerifyException(
-          IllegalArgumentException("ServiceSid or EntityIdentity is null or empty"), MapperError
+          IllegalArgumentException("ServiceSid or Identity is null or empty"), MapperError
       )
     }
     return when (factorPayload.type) {
-      PUSH -> toPushFactor(serviceSid, entityIdentity, jsonObject)
+      PUSH -> toPushFactor(serviceSid, identity, jsonObject)
     }
   }
 
@@ -68,16 +68,16 @@ internal class FactorMapper {
       throw TwilioVerifyException(e, MapperError)
     }
     val serviceSid = jsonObject.optString(serviceSidKey)
-    val entityIdentity = jsonObject.optString(entityIdentityKey)
-    if (serviceSid.isNullOrEmpty() || entityIdentity.isNullOrEmpty()) {
+    val identity = jsonObject.optString(identity)
+    if (serviceSid.isNullOrEmpty() || identity.isNullOrEmpty()) {
       throw TwilioVerifyException(
-          IllegalArgumentException("ServiceSid or EntityIdentity is null or empty"), MapperError
+          IllegalArgumentException("ServiceSid or Identity is null or empty"), MapperError
       )
     }
     return when (jsonObject.getString(typeKey)) {
       PUSH.factorTypeName -> toPushFactor(
           serviceSid,
-          entityIdentity,
+          identity,
           jsonObject
       ).apply {
         keyPairAlias = jsonObject.optString(keyPairAliasKey)
@@ -96,7 +96,7 @@ internal class FactorMapper {
           .put(friendlyNameKey, factor.friendlyName)
           .put(accountSidKey, factor.accountSid)
           .put(serviceSidKey, factor.serviceSid)
-          .put(entityIdentityKey, factor.entityIdentity)
+          .put(identity, factor.identity)
           .put(typeKey, factor.type.factorTypeName)
           .put(keyPairAliasKey, (factor as PushFactor).keyPairAlias)
           .put(statusKey, factor.status.value)
@@ -111,7 +111,7 @@ internal class FactorMapper {
   @Throws(TwilioVerifyException::class)
   private fun toPushFactor(
     serviceSid: String,
-    entityIdentity: String,
+    identity: String,
     jsonObject: JSONObject
   ): PushFactor {
     return try {
@@ -120,7 +120,7 @@ internal class FactorMapper {
           friendlyName = jsonObject.getString(friendlyNameKey),
           accountSid = jsonObject.getString(accountSidKey),
           serviceSid = serviceSid,
-          entityIdentity = entityIdentity,
+          identity = identity,
           status = FactorStatus.values()
               .find { it.value == jsonObject.getString(statusKey) }
               ?: Unverified,

--- a/verify/src/main/java/com/twilio/verify/domain/factor/PushFactory.kt
+++ b/verify/src/main/java/com/twilio/verify/domain/factor/PushFactory.kt
@@ -31,7 +31,7 @@ internal class PushFactory(
   private val context: Context
 ) {
   fun create(
-    jwe: String,
+    accessToken: String,
     friendlyName: String,
     pushToken: String,
     serviceSid: String,
@@ -46,7 +46,7 @@ internal class PushFactory(
       val config = config(pushToken)
       val factorBuilder = CreateFactorPayload(
           friendlyName, PUSH, serviceSid,
-          identity, config, binding, jwe
+          identity, config, binding, accessToken
       )
 
       fun onFactorCreated(factor: Factor) {
@@ -110,7 +110,7 @@ internal class PushFactory(
   ) {
     fun updateFactor(pushFactor: PushFactor) {
       val updateFactorPayload = UpdateFactorPayload(
-          pushFactor.friendlyName, PUSH, pushFactor.serviceSid, pushFactor.entityIdentity,
+          pushFactor.friendlyName, PUSH, pushFactor.serviceSid, pushFactor.identity,
           config(pushToken), pushFactor.sid
       )
       factorProvider.update(updateFactorPayload, success, error)

--- a/verify/src/main/java/com/twilio/verify/domain/factor/models/CreateFactorPayload.kt
+++ b/verify/src/main/java/com/twilio/verify/domain/factor/models/CreateFactorPayload.kt
@@ -9,8 +9,8 @@ internal data class CreateFactorPayload(
   override val friendlyName: String,
   override val type: FactorType,
   override val serviceSid: String,
-  override val entity: String,
+  override val identity: String,
   override val config: Map<String, String>,
   val binding: Map<String, String>,
-  val jwe: String
+  val accessToken: String
 ) : FactorDataPayload

--- a/verify/src/main/java/com/twilio/verify/domain/factor/models/FactorDataPayload.kt
+++ b/verify/src/main/java/com/twilio/verify/domain/factor/models/FactorDataPayload.kt
@@ -10,6 +10,6 @@ internal interface FactorDataPayload {
   val friendlyName: String
   val type: FactorType
   val serviceSid: String
-  val entity: String
+  val identity: String
   val config: Map<String, String>
 }

--- a/verify/src/main/java/com/twilio/verify/domain/factor/models/PushFactor.kt
+++ b/verify/src/main/java/com/twilio/verify/domain/factor/models/PushFactor.kt
@@ -15,7 +15,7 @@ internal class PushFactor(
   override val friendlyName: String,
   override val accountSid: String,
   override val serviceSid: String,
-  override val entityIdentity: String,
+  override val identity: String,
   override var status: FactorStatus = Unverified,
   override val createdAt: Date,
   val config: Config

--- a/verify/src/main/java/com/twilio/verify/domain/factor/models/UpdateFactorPayload.kt
+++ b/verify/src/main/java/com/twilio/verify/domain/factor/models/UpdateFactorPayload.kt
@@ -10,7 +10,7 @@ internal data class UpdateFactorPayload(
   override val friendlyName: String,
   override val type: FactorType,
   override val serviceSid: String,
-  override val entity: String,
+  override val identity: String,
   override val config: Map<String, String>,
   val factorSid: String
 ) : FactorDataPayload

--- a/verify/src/main/java/com/twilio/verify/models/Factor.kt
+++ b/verify/src/main/java/com/twilio/verify/models/Factor.kt
@@ -11,7 +11,7 @@ interface Factor {
   val friendlyName: String
   val accountSid: String
   val serviceSid: String
-  val entityIdentity: String
+  val identity: String
   val type: FactorType
   val createdAt: Date
 }

--- a/verify/src/main/java/com/twilio/verify/models/PushFactorPayload.kt
+++ b/verify/src/main/java/com/twilio/verify/models/PushFactorPayload.kt
@@ -8,7 +8,7 @@ class PushFactorPayload(
   override val serviceSid: String,
   override val identity: String,
   val pushToken: String,
-  val enrollmentJwe: String
+  val accessToken: String
 ) : FactorPayload {
   override val factorType: FactorType
     get() = FactorType.PUSH

--- a/verify/src/test/java/com/twilio/verify/TwilioVerifyTest.kt
+++ b/verify/src/test/java/com/twilio/verify/TwilioVerifyTest.kt
@@ -141,7 +141,7 @@ class TwilioVerifyTest {
         lastValue.invoke(Response(jsonObject.toString(), emptyMap()))
       }
     }
-    val jwe =
+    val accessToken =
       "eyJjdHkiOiJ0d2lsaW8tZnBhO3Y9MSIsInR5cCI6IkpXVCIsImFsZyI6IkhTMjU2In0.eyJpc3MiOiJTSz" +
           "AwMTBjZDc5Yzk4NzM1ZTBjZDliYjQ5NjBlZjYyZmI4IiwiZXhwIjoxNTgzOTM3NjY0LCJncmFudHMiOnsidmVyaW" +
           "Z5Ijp7ImlkZW50aXR5IjoiWUViZDE1NjUzZDExNDg5YjI3YzFiNjI1NTIzMDMwMTgxNSIsImZhY3RvciI6InB1c2" +
@@ -151,7 +151,7 @@ class TwilioVerifyTest {
           "VlMGNkOWJiNDk2MGVmNjJmYjgtMTU4Mzg1MTI2NCIsInN1YiI6IkFDYzg1NjNkYWY4OGVkMjZmMjI3NjM4ZjU3Mz" +
           "g3MjZmYmQifQ.R01YC9mfCzIf9W81GUUCMjTwnhzIIqxV-tcdJYuy6kA"
     val factorPayload =
-      PushFactorPayload("friendly name", factorServiceSid, factorIdentity, "pushToken", jwe)
+      PushFactorPayload("friendly name", factorServiceSid, factorIdentity, "pushToken", accessToken)
     idlingResource.startOperation()
     twilioVerify.createFactor(factorPayload, { factor ->
       assertEquals(jsonObject.getString(sidKey), factor.sid)
@@ -431,7 +431,7 @@ class TwilioVerifyTest {
         lastValue.invoke(Response(jsonObject.toString(), emptyMap()))
       }
     }
-    val jwe =
+    val accessToken =
       "eyJjdHkiOiJ0d2lsaW8tZnBhO3Y9MSIsInR5cCI6IkpXVCIsImFsZyI6IkhTMjU2In0.eyJpc3MiOiJTSz" +
           "AwMTBjZDc5Yzk4NzM1ZTBjZDliYjQ5NjBlZjYyZmI4IiwiZXhwIjoxNTgzOTM3NjY0LCJncmFudHMiOnsidmVyaW" +
           "Z5Ijp7ImlkZW50aXR5IjoiWUViZDE1NjUzZDExNDg5YjI3YzFiNjI1NTIzMDMwMTgxNSIsImZhY3RvciI6InB1c2" +
@@ -441,7 +441,7 @@ class TwilioVerifyTest {
           "VlMGNkOWJiNDk2MGVmNjJmYjgtMTU4Mzg1MTI2NCIsInN1YiI6IkFDYzg1NjNkYWY4OGVkMjZmMjI3NjM4ZjU3Mz" +
           "g3MjZmYmQifQ.R01YC9mfCzIf9W81GUUCMjTwnhzIIqxV-tcdJYuy6kA"
     val factorPayload =
-      PushFactorPayload("friendly name", factorServiceSid, factorIdentity, "pushToken", jwe)
+      PushFactorPayload("friendly name", factorServiceSid, factorIdentity, "pushToken", accessToken)
     idlingResource.startOperation()
     twilioVerify.createFactor(factorPayload, { factor ->
       this.factor = factor

--- a/verify/src/test/java/com/twilio/verify/api/ChallengeAPIClientTest.kt
+++ b/verify/src/test/java/com/twilio/verify/api/ChallengeAPIClientTest.kt
@@ -59,7 +59,7 @@ class ChallengeAPIClientTest {
     FactorChallenge("sid", mock(), "", "factorSid", Pending, Date(), Date(), Date()).apply {
       factor =
         PushFactor(
-            "sid", "friendlyName", "accountSid", "serviceSid", "entityIdentity", createdAt = Date(),
+            "sid", "friendlyName", "accountSid", "serviceSid", "identity", createdAt = Date(),
             config = Config("credentialSid")
         )
     }
@@ -212,7 +212,7 @@ class ChallengeAPIClientTest {
       "$baseUrl$updateChallengeURL".replace(
           SERVICE_SID_PATH, factorChallenge.factor!!.serviceSid, true
       )
-          .replace(IDENTITY_PATH, factorChallenge.factor!!.entityIdentity)
+          .replace(IDENTITY_PATH, factorChallenge.factor!!.identity)
           .replace(challengeSidPath, factorChallenge.sid)
 
     val authPayload = "authPayload"
@@ -398,7 +398,7 @@ class ChallengeAPIClientTest {
     val factor = factorChallenge.factor!!
     val expectedURL =
       "$baseUrl$getChallengeURL".replace(SERVICE_SID_PATH, factor.serviceSid, true)
-          .replace(IDENTITY_PATH, factor.entityIdentity)
+          .replace(IDENTITY_PATH, factor.identity)
           .replace(challengeSidPath, challengeSid)
     whenever(authentication.generateJWT(factorChallenge.factor!!)).thenReturn("authToken")
     idlingResource.startOperation()

--- a/verify/src/test/java/com/twilio/verify/api/FactorAPIClientTest.kt
+++ b/verify/src/test/java/com/twilio/verify/api/FactorAPIClientTest.kt
@@ -82,7 +82,7 @@ class FactorAPIClientTest {
       }
     }
     factorAPIClient.create(CreateFactorPayload(
-        "factor name", PUSH, "serviceSid123", "entitySid123", emptyMap(), emptyMap(), "jwe"
+        "factor name", PUSH, "serviceSid123", "entitySid123", emptyMap(), emptyMap(), "accessToken"
     ), { jsonObject ->
       assertEquals(response, jsonObject.toString())
     }, {
@@ -105,7 +105,7 @@ class FactorAPIClientTest {
       }
     }
     factorAPIClient.create(CreateFactorPayload(
-        "factor name", PUSH, "serviceSid123", "entitySid123", emptyMap(), emptyMap(), "jwe"
+        "factor name", PUSH, "serviceSid123", "entitySid123", emptyMap(), emptyMap(), "accessToken"
     ), {
       fail()
     }, { exception ->
@@ -117,7 +117,7 @@ class FactorAPIClientTest {
   fun `Error creating a factor should call error`() {
     val factorPayload =
       CreateFactorPayload(
-          "factor name", PUSH, "serviceSid", "entitySid", emptyMap(), emptyMap(), "jwe"
+          "factor name", PUSH, "serviceSid", "entitySid", emptyMap(), emptyMap(), "accessToken"
       )
     whenever(networkProvider.execute(any(), any(), any())).thenThrow(RuntimeException())
     factorAPIClient.create(factorPayload, {
@@ -132,10 +132,10 @@ class FactorAPIClientTest {
   @Test
   fun `Create factor request should match to the expected params`() {
     val serviceSid = "serviceSid"
-    val entity = "entityId"
+    val identity = "identity"
     val expectedURL = "$baseUrl$CREATE_FACTOR_URL".replace(SERVICE_SID_PATH, serviceSid, true)
         .replace(
-            IDENTITY_PATH, entity
+            IDENTITY_PATH, identity
         )
     val friendlyNameMock = "Test"
     val factorTypeMock = PUSH
@@ -158,7 +158,7 @@ class FactorAPIClientTest {
       CreateFactorPayload(
           friendlyNameMock, factorTypeMock,
           serviceSid,
-          entity, config, binding, "jwe"
+          identity, config, binding, "accessToken"
       )
 
     factorAPIClient.create(factorPayload, {}, {})
@@ -179,7 +179,7 @@ class FactorAPIClientTest {
 
   @Test
   fun `Verify a factor with a success response should call success`() {
-    val identity = "entityIdentity"
+    val identity = "identity"
     val factorSid = "sid"
     val serviceSid = "serviceSid"
     val response = "{\"key\":\"value\"}"
@@ -212,7 +212,7 @@ class FactorAPIClientTest {
 
   @Test
   fun `Verify a factor with out of sync time should sync time and redo the request`() {
-    val identity = "entityIdentity"
+    val identity = "identity"
     val factorSid = "sid"
     val serviceSid = "serviceSid"
     val response = "{\"key\":\"value\"}"
@@ -258,7 +258,7 @@ class FactorAPIClientTest {
 
   @Test
   fun `Verify a factor with out of sync time should retry only another time`() {
-    val identity = "entityIdentity"
+    val identity = "identity"
     val factorSid = "sid"
     val serviceSid = "serviceSid"
     val date = "Tue, 21 Jul 2020 17:07:32 GMT"
@@ -300,7 +300,7 @@ class FactorAPIClientTest {
 
   @Test
   fun `Verify a factor with an error response should not call success`() {
-    val identity = "entityIdentity"
+    val identity = "identity"
     val factorSid = "sid"
     val serviceSid = "serviceSid"
     val expectedException = NetworkException(
@@ -343,10 +343,10 @@ class FactorAPIClientTest {
     val friendlyNameMock = "friendlyName"
     val accountSidMock = "accountSid"
     val serviceSidMock = "serviceSid"
-    val entityIdentityMock = "entityIdentity"
+    val identityMock = "identity"
     val authPayloadMock = "authPayload"
     val expectedURL = "$baseUrl$VERIFY_FACTOR_URL".replace(SERVICE_SID_PATH, serviceSidMock, true)
-        .replace(IDENTITY_PATH, entityIdentityMock)
+        .replace(IDENTITY_PATH, identityMock)
         .replace(FACTOR_SID_PATH, sidMock)
     val expectedBody = mapOf(AUTH_PAYLOAD_PARAM to authPayloadMock)
     val factor =
@@ -355,7 +355,7 @@ class FactorAPIClientTest {
           friendlyNameMock,
           accountSidMock,
           serviceSidMock,
-          entityIdentityMock,
+          identityMock,
           Unverified,
           Date(),
           config = Config("credentialSid")
@@ -381,7 +381,7 @@ class FactorAPIClientTest {
 
   @Test
   fun `Update factor with a success response should call success`() {
-    val identity = "entityIdentity"
+    val identity = "identity"
     val factorSid = "sid"
     val serviceSid = "serviceSid"
     val response = "{\"key\":\"value\"}"
@@ -411,7 +411,7 @@ class FactorAPIClientTest {
 
   @Test
   fun `Update factor with out of sync time should sync time and redo the request`() {
-    val identity = "entityIdentity"
+    val identity = "identity"
     val factorSid = "sid"
     val serviceSid = "serviceSid"
     val response = "{\"key\":\"value\"}"
@@ -454,7 +454,7 @@ class FactorAPIClientTest {
 
   @Test
   fun `Update factor with out of sync time should retry only another time`() {
-    val identity = "entityIdentity"
+    val identity = "identity"
     val factorSid = "sid"
     val serviceSid = "serviceSid"
     val factor =
@@ -494,7 +494,7 @@ class FactorAPIClientTest {
 
   @Test
   fun `Update a factor with an error response shouldn't call success`() {
-    val identity = "entityIdentity"
+    val identity = "identity"
     val factorSid = "sid"
     val serviceSid = "serviceSid"
     val factor =
@@ -534,11 +534,11 @@ class FactorAPIClientTest {
     val sidMock = "sid"
     val serviceSidMock = "serviceSid"
     val friendlyNameMock = "Test"
-    val entityIdentityMock = "entityIdentity"
+    val identityMock = "identity"
     val pushToken = "ABCD"
     val factorTypeMock = PUSH
     val expectedURL = "$baseUrl$UPDATE_FACTOR_URL".replace(SERVICE_SID_PATH, serviceSidMock, true)
-        .replace(IDENTITY_PATH, entityIdentityMock)
+        .replace(IDENTITY_PATH, identityMock)
         .replace(FACTOR_SID_PATH, sidMock)
 
     val config = mapOf(
@@ -549,13 +549,13 @@ class FactorAPIClientTest {
     )
     val factor =
       PushFactor(
-          sidMock, "friendlyName", "accountSid", serviceSidMock, entityIdentityMock, Verified,
+          sidMock, "friendlyName", "accountSid", serviceSidMock, identityMock, Verified,
           Date(), config = Config("credentialSid")
       )
     val factorPayload =
       UpdateFactorPayload(
           friendlyNameMock, factorTypeMock, serviceSidMock,
-          entityIdentityMock, config, sidMock
+          identityMock, config, sidMock
       )
 
     val expectedBody = mapOf(
@@ -583,7 +583,7 @@ class FactorAPIClientTest {
 
   @Test
   fun `Delete a factor with a success response should call success`() {
-    val identity = "entityIdentity"
+    val identity = "identity"
     val factorSid = "sid"
     val serviceSid = "serviceSid"
     val response = "{\"key\":\"value\"}"
@@ -620,7 +620,7 @@ class FactorAPIClientTest {
 
   @Test
   fun `Delete a factor with out of sync time should sync time and redo the request`() {
-    val identity = "entityIdentity"
+    val identity = "identity"
     val factorSid = "sid"
     val serviceSid = "serviceSid"
     val response = "{\"key\":\"value\"}"
@@ -671,7 +671,7 @@ class FactorAPIClientTest {
 
   @Test
   fun `Delete a factor with out of sync time should retry only another time`() {
-    val identity = "entityIdentity"
+    val identity = "identity"
     val factorSid = "sid"
     val serviceSid = "serviceSid"
     val factor =
@@ -709,7 +709,7 @@ class FactorAPIClientTest {
 
   @Test
   fun `Delete a factor with an error response should not call success`() {
-    val identity = "entityIdentity"
+    val identity = "identity"
     val factorSid = "sid"
     val serviceSid = "serviceSid"
     val factor =
@@ -743,7 +743,7 @@ class FactorAPIClientTest {
 
   @Test
   fun `Delete a factor with an exception should not call success`() {
-    val identity = "entityIdentity"
+    val identity = "identity"
     val factorSid = "sid"
     val serviceSid = "serviceSid"
     val factor =

--- a/verify/src/test/java/com/twilio/verify/api/ServiceAPIClientTest.kt
+++ b/verify/src/test/java/com/twilio/verify/api/ServiceAPIClientTest.kt
@@ -66,7 +66,7 @@ class ServiceAPIClientTest {
     val factorSid = "sid"
     val factorServiceSid = "serviceSid"
     val factor: Factor = mock() {
-      on { entityIdentity } doReturn identity
+      on { this.identity } doReturn identity
       on { sid } doReturn factorSid
       on { serviceSid } doReturn factorServiceSid
     }
@@ -94,7 +94,7 @@ class ServiceAPIClientTest {
     val factorSid = "sid"
     val factorServiceSid = "serviceSid"
     val factor: Factor = mock() {
-      on { entityIdentity } doReturn identity
+      on { this.identity } doReturn identity
       on { sid } doReturn factorSid
       on { serviceSid } doReturn factorServiceSid
     }
@@ -128,7 +128,7 @@ class ServiceAPIClientTest {
     val factorSid = "sid"
     val factorServiceSid = "serviceSid"
     val factor: Factor = mock() {
-      on { entityIdentity } doReturn identity
+      on { this.identity } doReturn identity
       on { sid } doReturn factorSid
       on { serviceSid } doReturn factorServiceSid
     }
@@ -170,7 +170,7 @@ class ServiceAPIClientTest {
     val factorSid = "sid"
     val factorServiceSid = "serviceSid"
     val factor: Factor = mock() {
-      on { entityIdentity } doReturn identity
+      on { this.identity } doReturn identity
       on { sid } doReturn factorSid
       on { serviceSid } doReturn factorServiceSid
     }
@@ -208,7 +208,7 @@ class ServiceAPIClientTest {
     val factorSid = "sid"
     val factorServiceSid = "serviceSid"
     val factor: Factor = mock() {
-      on { entityIdentity } doReturn identity
+      on { this.identity } doReturn identity
       on { sid } doReturn factorSid
       on { serviceSid } doReturn factorServiceSid
     }
@@ -232,7 +232,7 @@ class ServiceAPIClientTest {
     val factorSid = "sid"
     val factorServiceSid = "serviceSid"
     val factor: Factor = mock() {
-      on { entityIdentity } doReturn identity
+      on { this.identity } doReturn identity
       on { sid } doReturn factorSid
       on { serviceSid } doReturn factorServiceSid
     }

--- a/verify/src/test/java/com/twilio/verify/domain/TwilioVerifyManagerTest.kt
+++ b/verify/src/test/java/com/twilio/verify/domain/TwilioVerifyManagerTest.kt
@@ -44,7 +44,7 @@ class TwilioVerifyManagerTest {
   @Test
   fun `Create a factor should call success`() {
     val factorPayload =
-      PushFactorPayload("friendly name", "serviceSid", "identity", "pushToken", "jwe")
+      PushFactorPayload("friendly name", "serviceSid", "identity", "pushToken", "accessToken")
     val expectedFactor: Factor = mock()
     argumentCaptor<(Factor) -> Unit>().apply {
       whenever(factorFacade.createFactor(eq(factorPayload), capture(), any())).then {
@@ -65,7 +65,7 @@ class TwilioVerifyManagerTest {
   @Test
   fun `Error creating a factor should call error`() {
     val factorPayload =
-      PushFactorPayload("friendly name", "serviceSid", "identity", "pushToken", "jwe")
+      PushFactorPayload("friendly name", "serviceSid", "identity", "pushToken", "accessToken")
     val expectedException: Exception = mock()
     argumentCaptor<(TwilioVerifyException) -> Unit>().apply {
       whenever(factorFacade.createFactor(eq(factorPayload), any(), capture())).then {

--- a/verify/src/test/java/com/twilio/verify/domain/challenge/PushChallengeProcessorTest.kt
+++ b/verify/src/test/java/com/twilio/verify/domain/challenge/PushChallengeProcessorTest.kt
@@ -135,7 +135,7 @@ class PushChallengeProcessorTest {
     val factorSid = "sid123"
     val accountSid = "accountSid"
     val serviceSid = "serviceSid"
-    val entityId = "entityId"
+    val identity = "identity"
     val hiddenDetails = "hiddenDetails"
     val newStatus = Denied
     val status = Pending
@@ -156,7 +156,7 @@ class PushChallengeProcessorTest {
     whenever(factor.sid).thenReturn(factorSid)
     whenever(factor.accountSid).thenReturn(accountSid)
     whenever(factor.serviceSid).thenReturn(serviceSid)
-    whenever(factor.entityIdentity).thenReturn(entityId)
+    whenever(factor.identity).thenReturn(identity)
     argumentCaptor<(Challenge) -> Unit>().apply {
       whenever(challengeProvider.get(eq(sid), eq(factor), capture(), any())).then {
         firstValue.invoke(challenge)

--- a/verify/src/test/java/com/twilio/verify/domain/factor/FactorFacadeTest.kt
+++ b/verify/src/test/java/com/twilio/verify/domain/factor/FactorFacadeTest.kt
@@ -39,12 +39,12 @@ class FactorFacadeTest {
   @Test
   fun `Create a factor should call success`() {
     val factorPayload =
-      PushFactorPayload("friendly name", "serviceSid", "identity", "pushToken", "jwe")
+      PushFactorPayload("friendly name", "serviceSid", "identity", "pushToken", "accessToken")
     val expectedFactor: Factor = mock()
     argumentCaptor<(Factor) -> Unit>().apply {
       whenever(
           pushFactory.create(
-              eq(factorPayload.enrollmentJwe), eq(factorPayload.friendlyName), eq(factorPayload.pushToken),
+              eq(factorPayload.accessToken), eq(factorPayload.friendlyName), eq(factorPayload.pushToken),
               eq(factorPayload.serviceSid), eq(factorPayload.identity), capture(), any()
           )
       ).then {
@@ -65,12 +65,12 @@ class FactorFacadeTest {
   @Test
   fun `Error creating a factor should call error`() {
     val factorPayload =
-      PushFactorPayload("friendly name", "serviceSid", "identity", "pushToken", "jwe")
+      PushFactorPayload("friendly name", "serviceSid", "identity", "pushToken", "accessToken")
     val expectedException: Exception = mock()
     argumentCaptor<(TwilioVerifyException) -> Unit>().apply {
       whenever(
           pushFactory.create(
-              eq(factorPayload.enrollmentJwe), eq(factorPayload.friendlyName), eq(factorPayload.pushToken),
+              eq(factorPayload.accessToken), eq(factorPayload.friendlyName), eq(factorPayload.pushToken),
               eq(factorPayload.serviceSid), eq(factorPayload.identity), any(), capture()
           )
       ).then {

--- a/verify/src/test/java/com/twilio/verify/domain/factor/FactorMapperTest.kt
+++ b/verify/src/test/java/com/twilio/verify/domain/factor/FactorMapperTest.kt
@@ -36,7 +36,7 @@ class FactorMapperTest {
   fun `Map a valid response from API with factorPayload should return a factor`() {
     val factorPayload =
       CreateFactorPayload(
-          "factor name", PUSH, "serviceSid123", "entityId123", emptyMap(), emptyMap(), "jwe"
+          "factor name", PUSH, "serviceSid123", "identity123", emptyMap(), emptyMap(), "accessToken"
       )
     val jsonObject = JSONObject()
         .put(sidKey, "sid123")
@@ -48,7 +48,7 @@ class FactorMapperTest {
     val factor = factorMapper.fromApi(jsonObject, factorPayload) as PushFactor
     assertEquals(factorPayload.type, factor.type)
     assertEquals(factorPayload.serviceSid, factor.serviceSid)
-    assertEquals(factorPayload.entity, factor.entityIdentity)
+    assertEquals(factorPayload.identity, factor.identity)
     assertEquals(jsonObject.getString(sidKey), factor.sid)
     assertEquals(jsonObject.getString(friendlyNameKey), factor.friendlyName)
     assertEquals(jsonObject.getString(accountSidKey), factor.accountSid)
@@ -60,7 +60,7 @@ class FactorMapperTest {
   fun `Map an incomplete response from API should throw an exception`() {
     val factorPayload =
       CreateFactorPayload(
-          "factor name", PUSH, "serviceSid123", "entitySid123", emptyMap(), emptyMap(), "jwe"
+          "factor name", PUSH, "serviceSid123", "entitySid123", emptyMap(), emptyMap(), "accessToken"
       )
     val jsonObject = JSONObject()
         .put(friendlyNameKey, "factor name")
@@ -83,7 +83,7 @@ class FactorMapperTest {
   @Test
   fun `Map a response with invalid serviceSid in payload from API should throw an exception`() {
     val factorPayload =
-      CreateFactorPayload("factor name", PUSH, "", "entitySid123", emptyMap(), emptyMap(), "jwe")
+      CreateFactorPayload("factor name", PUSH, "", "entitySid123", emptyMap(), emptyMap(), "accessToken")
     val jsonObject = JSONObject()
         .put(sidKey, "sid123")
         .put(friendlyNameKey, "factor name")
@@ -98,7 +98,7 @@ class FactorMapperTest {
   fun `Map a response without factor sid from API should throw an exception`() {
     val factorPayload =
       CreateFactorPayload(
-          "factor name", PUSH, "serviceSid123", "entitySid123", emptyMap(), emptyMap(), "jwe"
+          "factor name", PUSH, "serviceSid123", "entitySid123", emptyMap(), emptyMap(), "accessToken"
       )
     val jsonObject = JSONObject()
         .put(friendlyNameKey, "factor name")
@@ -113,7 +113,7 @@ class FactorMapperTest {
   fun `Map a response without entity sid from API should throw an exception`() {
     val factorPayload =
       CreateFactorPayload(
-          "factor name", PUSH, "serviceSid123", "entitySid123", emptyMap(), emptyMap(), "jwe"
+          "factor name", PUSH, "serviceSid123", "entitySid123", emptyMap(), emptyMap(), "accessToken"
       )
     val jsonObject = JSONObject()
         .put(sidKey, "sid123")
@@ -133,7 +133,7 @@ class FactorMapperTest {
         .put(friendlyNameKey, "factor name")
         .put(accountSidKey, "accountSid123")
         .put(serviceSidKey, "serviceSid123")
-        .put(entityIdentityKey, "entityId123")
+        .put(identity, "identity123")
         .put(typeKey, PUSH.factorTypeName)
         .put(keyPairAliasKey, "keyPairAlias123")
         .put(statusKey, Unverified.value)
@@ -158,7 +158,7 @@ class FactorMapperTest {
         .put(accountSidKey, "accountSid123")
         .put(typeKey, PUSH.factorTypeName)
         .put(keyPairAliasKey, "keyPairAlias123")
-        .put(entityIdentityKey, "entityId123")
+        .put(identity, "identity123")
     exceptionRule.expect(TwilioVerifyException::class.java)
     exceptionRule.expectCause(instanceOf(IllegalArgumentException::class.java))
     exceptionRule.expect(ErrorCodeMatcher(MapperError))
@@ -172,7 +172,7 @@ class FactorMapperTest {
         .put(friendlyNameKey, "factor name")
         .put(accountSidKey, "accountSid123")
         .put(serviceSidKey, "serviceSid123")
-        .put(entityIdentityKey, "entityId123")
+        .put(identity, "identity123")
         .put(typeKey, "test")
         .put(keyPairAliasKey, "keyPairAlias123")
     exceptionRule.expect(TwilioVerifyException::class.java)
@@ -194,7 +194,7 @@ class FactorMapperTest {
   fun `Map a factor to JSON should return complete factor data as JSONObject`() {
     val factor = PushFactor(
         sid = "sid123", friendlyName = "factor name", accountSid = "accountSid123",
-        serviceSid = "serviceSid123", entityIdentity = "entityIdentity123", status = Unverified,
+        serviceSid = "serviceSid123", identity = "identity123", status = Unverified,
         createdAt = Date(), config = Config("credentialSid")
     ).apply { keyPairAlias = "keyPairAlias123" }
     val json = factorMapper.toJSON(factor)
@@ -204,7 +204,7 @@ class FactorMapperTest {
     assertEquals(factor.sid, jsonObject.getString(sidKey))
     assertEquals(factor.friendlyName, jsonObject.getString(friendlyNameKey))
     assertEquals(factor.accountSid, jsonObject.getString(accountSidKey))
-    assertEquals(factor.entityIdentity, jsonObject.getString(entityIdentityKey))
+    assertEquals(factor.identity, jsonObject.getString(identity))
     assertEquals(factor.keyPairAlias, jsonObject.getString(keyPairAliasKey))
     assertEquals(toRFC3339Date(factor.createdAt), jsonObject.getString(dateCreatedKey))
   }

--- a/verify/src/test/java/com/twilio/verify/domain/factor/FactorRepositoryTest.kt
+++ b/verify/src/test/java/com/twilio/verify/domain/factor/FactorRepositoryTest.kt
@@ -53,7 +53,7 @@ class FactorRepositoryTest {
     val sid = "sid123"
     val factorPayload = CreateFactorPayload(
         "factor name", PUSH, "serviceSid123", "entitySid123", emptyMap(),
-        emptyMap(), "jwe"
+        emptyMap(), "accessToken"
     )
     val response = JSONObject()
         .put(sidKey, sid)
@@ -83,7 +83,7 @@ class FactorRepositoryTest {
   fun `No response from API creating a factor should call error`() {
     val factorPayload = CreateFactorPayload(
         "factor name", PUSH, "serviceSid123", "entitySid123",
-        emptyMap(), emptyMap(), "jwe"
+        emptyMap(), emptyMap(), "accessToken"
     )
     val expectedException: TwilioVerifyException = mock()
     argumentCaptor<(TwilioVerifyException) -> Unit>().apply {
@@ -103,7 +103,7 @@ class FactorRepositoryTest {
     val sid = "sid123"
     val factorPayload = CreateFactorPayload(
         "factor name", PUSH, "serviceSid123", "entitySid123",
-        emptyMap(), emptyMap(), "jwe"
+        emptyMap(), emptyMap(), "accessToken"
     )
     val response = JSONObject()
         .put(sidKey, sid)
@@ -128,7 +128,7 @@ class FactorRepositoryTest {
     val sid = "sid123"
     val factorPayload = CreateFactorPayload(
         "factor name", PUSH, "serviceSid123", "entitySid123",
-        emptyMap(), emptyMap(), "jwe"
+        emptyMap(), emptyMap(), "accessToken"
     )
     val response = JSONObject()
         .put(sidKey, sid)
@@ -229,7 +229,7 @@ class FactorRepositoryTest {
         "friendlyName",
         "accountSid",
         "serviceSid",
-        "entityIdentity",
+        "identity",
         FactorStatus.Unverified,
         Date(),
         Config("credentialSid")
@@ -269,7 +269,7 @@ class FactorRepositoryTest {
         "friendlyName",
         "accountSid",
         "serviceSid",
-        "entityIdentity",
+        "identity",
         FactorStatus.Unverified,
         Date(),
         Config("credentialSid")

--- a/verify/src/test/java/com/twilio/verify/domain/factor/PushFactoryTest.kt
+++ b/verify/src/test/java/com/twilio/verify/domain/factor/PushFactoryTest.kt
@@ -44,10 +44,9 @@ class PushFactoryTest {
   private val idlingResource = IdlingResource()
 
   @Test
-  fun `Create factor with valid JWE should call success lambda`() {
+  fun `Create factor with valid accessToken should call success lambda`() {
     val serviceSid = "ISb3a64ae0d2262a2bad5e9870c448b83a"
-    val entityId = "YEbd15653d11489b27c1b6255230301815"
-    val jwe =
+    val accessToken =
       "eyJjdHkiOiJ0d2lsaW8tZnBhO3Y9MSIsInR5cCI6IkpXVCIsImFsZyI6IkhTMjU2In0.eyJpc3MiOiJTSz" +
           "AwMTBjZDc5Yzk4NzM1ZTBjZDliYjQ5NjBlZjYyZmI4IiwiZXhwIjoxNTgzOTM3NjY0LCJncmFudHMiOnsidmVyaW" +
           "Z5Ijp7ImlkZW50aXR5IjoiWUViZDE1NjUzZDExNDg5YjI3YzFiNjI1NTIzMDMwMTgxNSIsImZhY3RvciI6InB1c2" +
@@ -76,7 +75,7 @@ class PushFactoryTest {
     }
     val pushFactor =
       PushFactor(
-          "1", friendlyName, "1", serviceSid, entityId, createdAt = Date(),
+          "1", friendlyName, "1", serviceSid, identity, createdAt = Date(),
           config = Config("credentialSid")
       )
     argumentCaptor<(Factor) -> Unit>().apply {
@@ -85,12 +84,12 @@ class PushFactoryTest {
       }
     }
     idlingResource.startOperation()
-    pushFactory.create(jwe, friendlyName, pushToken, serviceSid, identity, {
+    pushFactory.create(accessToken, friendlyName, pushToken, serviceSid, identity, {
       verify(factorProvider).create(check { pushFactor ->
         assertEquals(expectedBinding, pushFactor.binding)
         assertEquals(expectedConfig, pushFactor.config)
         assertEquals(serviceSid, pushFactor.serviceSid)
-        assertEquals(identity, pushFactor.entity)
+        assertEquals(identity, pushFactor.identity)
         assertEquals(friendlyName, pushFactor.friendlyName)
       }, any(), any())
       verify(factorProvider).save(check {
@@ -108,7 +107,7 @@ class PushFactoryTest {
 
   @Test
   fun `Keypair not created creating a factor should call error lambda`() {
-    val jwe =
+    val accessToken =
       "eyJjdHkiOiJ0d2lsaW8tZnBhO3Y9MSIsInR5cCI6IkpXVCIsImFsZyI6IkhTMjU2In0.eyJpc3MiOiJTSz" +
           "AwMTBjZDc5Yzk4NzM1ZTBjZDliYjQ5NjBlZjYyZmI4IiwiZXhwIjoxNTgzOTM3NjY0LCJncmFudHMiOnsidmVyaW" +
           "Z5Ijp7ImlkZW50aXR5IjoiWUViZDE1NjUzZDExNDg5YjI3YzFiNjI1NTIzMDMwMTgxNSIsImZhY3RvciI6InB1c2" +
@@ -125,7 +124,7 @@ class PushFactoryTest {
       throw TwilioVerifyException(IllegalStateException(), KeyStorageError)
     }
     idlingResource.startOperation()
-    pushFactory.create(jwe, friendlyName, pushToken, serviceSid, identity, {
+    pushFactory.create(accessToken, friendlyName, pushToken, serviceSid, identity, {
       fail()
       idlingResource.operationFinished()
     }, { exception ->
@@ -138,7 +137,7 @@ class PushFactoryTest {
 
   @Test
   fun `Error in factor provider creating the factor should call error lambda`() {
-    val jwe =
+    val accessToken =
       "eyJjdHkiOiJ0d2lsaW8tZnBhO3Y9MSIsInR5cCI6IkpXVCIsImFsZyI6IkhTMjU2In0.eyJpc3MiOiJTSz" +
           "AwMTBjZDc5Yzk4NzM1ZTBjZDliYjQ5NjBlZjYyZmI4IiwiZXhwIjoxNTgzOTM3NjY0LCJncmFudHMiOnsidmVyaW" +
           "Z5Ijp7ImlkZW50aXR5IjoiWUViZDE1NjUzZDExNDg5YjI3YzFiNjI1NTIzMDMwMTgxNSIsImZhY3RvciI6InB1c2" +
@@ -166,7 +165,7 @@ class PushFactoryTest {
       }
     }
     idlingResource.startOperation()
-    pushFactory.create(jwe, friendlyName, pushToken, serviceSid, identity, {
+    pushFactory.create(accessToken, friendlyName, pushToken, serviceSid, identity, {
       fail()
       idlingResource.operationFinished()
     }, { exception ->
@@ -179,7 +178,7 @@ class PushFactoryTest {
 
   @Test
   fun `Empty keypair in push factor creating a factor should call error lambda`() {
-    val jwe =
+    val accessToken =
       "eyJjdHkiOiJ0d2lsaW8tZnBhO3Y9MSIsInR5cCI6IkpXVCIsImFsZyI6IkhTMjU2In0.eyJpc3MiOiJTSz" +
           "AwMTBjZDc5Yzk4NzM1ZTBjZDliYjQ5NjBlZjYyZmI4IiwiZXhwIjoxNTgzOTM3NjY0LCJncmFudHMiOnsidmVyaW" +
           "Z5Ijp7ImlkZW50aXR5IjoiWUViZDE1NjUzZDExNDg5YjI3YzFiNjI1NTIzMDMwMTgxNSIsImZhY3RvciI6InB1c2" +
@@ -208,7 +207,7 @@ class PushFactoryTest {
       }
     }
     idlingResource.startOperation()
-    pushFactory.create(jwe, friendlyName, pushToken, serviceSid, identity, {
+    pushFactory.create(accessToken, friendlyName, pushToken, serviceSid, identity, {
       fail()
       idlingResource.operationFinished()
     }, { exception ->
@@ -223,7 +222,7 @@ class PushFactoryTest {
   fun `Verify factor with stored factor should call success`() {
     val sid = "sid"
     val serviceSid = "ISbb7823aa5dcce90443f856406abd7000"
-    val entityId = "entityId"
+    val identity = "identity"
     val friendlyName = "factor name"
     val accountSid = "accountSid"
     val status = FactorStatus.Unverified
@@ -236,7 +235,7 @@ class PushFactoryTest {
           friendlyName,
           accountSid,
           serviceSid,
-          entityId,
+          identity,
           status,
           Date(),
           Config("credentialSid")
@@ -256,7 +255,7 @@ class PushFactoryTest {
       assertEquals(PUSH, it.type)
       assertEquals(status, it.status)
       assertEquals(accountSid, it.accountSid)
-      assertEquals(entityId, it.entityIdentity)
+      assertEquals(identity, it.identity)
       assertEquals(sid, it.sid)
       assertEquals(credentialSid, (it as PushFactor).config.credentialSid)
       verify(keyStorage).signAndEncode(keyPairAlias, it.sid)
@@ -287,7 +286,7 @@ class PushFactoryTest {
   fun `Verify factor with API error should call error`() {
     val sid = "sid"
     val serviceSid = "ISbb7823aa5dcce90443f856406abd7000"
-    val entityId = "entityId"
+    val identity = "identity"
     val friendlyName = "factor name"
     val accountSid = "accountSid"
     val status = FactorStatus.Unverified
@@ -300,7 +299,7 @@ class PushFactoryTest {
           friendlyName,
           accountSid,
           serviceSid,
-          entityId,
+          identity,
           status,
           Date(),
           Config("credentialSid")
@@ -329,7 +328,7 @@ class PushFactoryTest {
   fun `Verify factor with null alias should call error`() {
     val sid = "sid"
     val serviceSid = "ISbb7823aa5dcce90443f856406abd7000"
-    val entityId = "entityId"
+    val identity = "identity"
     val friendlyName = "factor name"
     val accountSid = "accountSid"
     val status = FactorStatus.Unverified
@@ -337,7 +336,7 @@ class PushFactoryTest {
     val keyPairAlias = null
     val factor =
       PushFactor(
-          sid, friendlyName, accountSid, serviceSid, entityId, status, Date(), Config(credentialSid)
+          sid, friendlyName, accountSid, serviceSid, identity, status, Date(), Config(credentialSid)
       )
     factor.keyPairAlias = keyPairAlias
     whenever(factorProvider.get(sid)).thenReturn(factor)
@@ -357,7 +356,7 @@ class PushFactoryTest {
     val sid = "sid"
     val pushToken = "pushToken"
     val serviceSid = "ISbb7823aa5dcce90443f856406abd7000"
-    val entityId = "entityId"
+    val identity = "identity"
     val friendlyName = "factor name"
     val accountSid = "accountSid"
     val credentialSid = "credentialSid"
@@ -368,7 +367,7 @@ class PushFactoryTest {
           friendlyName,
           accountSid,
           serviceSid,
-          entityId,
+          identity,
           status,
           Date(),
           Config("credentialSid")
@@ -385,7 +384,7 @@ class PushFactoryTest {
         assertEquals(sid, updateFactorPayload.factorSid)
         assertEquals(serviceSid, updateFactorPayload.serviceSid)
         assertEquals(friendlyName, updateFactorPayload.friendlyName)
-        assertEquals(entityId, updateFactorPayload.entity)
+        assertEquals(identity, updateFactorPayload.identity)
         assertEquals(PUSH, updateFactorPayload.type)
         assertEquals(pushToken, updateFactorPayload.config[NOTIFICATION_TOKEN_KEY])
       }, any(), any())
@@ -394,7 +393,7 @@ class PushFactoryTest {
       assertEquals(PUSH, it.type)
       assertEquals(status, it.status)
       assertEquals(accountSid, it.accountSid)
-      assertEquals(entityId, it.entityIdentity)
+      assertEquals(identity, it.identity)
       assertEquals(sid, it.sid)
       assertEquals(credentialSid, (it as PushFactor).config.credentialSid)
       idlingResource.operationFinished()
@@ -425,18 +424,17 @@ class PushFactoryTest {
   fun `Update factor with API error should call error`() {
     val sid = "sid"
     val serviceSid = "ISbb7823aa5dcce90443f856406abd7000"
-    val entityId = "entityId"
+    val identity = "identity"
     val friendlyName = "factor name"
     val accountSid = "accountSid"
     val status = FactorStatus.Unverified
-    val credentialSid = "credentialSid"
     val factor =
       PushFactor(
           sid,
           friendlyName,
           accountSid,
           serviceSid,
-          entityId,
+          identity,
           status,
           Date(),
           Config("credentialSid")
@@ -463,7 +461,7 @@ class PushFactoryTest {
   fun `Delete factor with stored factor should call success and delete factor alias from key storage`() {
     val sid = "sid"
     val serviceSid = "ISbb7823aa5dcce90443f856406abd7000"
-    val entityId = "entityId"
+    val identity = "identity"
     val friendlyName = "factor name"
     val accountSid = "accountSid"
     val status = FactorStatus.Unverified
@@ -475,7 +473,7 @@ class PushFactoryTest {
           friendlyName,
           accountSid,
           serviceSid,
-          entityId,
+          identity,
           status,
           Date(),
           Config(credentialSid)
@@ -495,7 +493,7 @@ class PushFactoryTest {
         assertEquals(sid, factor.sid)
         assertEquals(serviceSid, factor.serviceSid)
         assertEquals(friendlyName, factor.friendlyName)
-        assertEquals(entityId, factor.entityIdentity)
+        assertEquals(identity, factor.identity)
         assertEquals(PUSH, factor.type)
       }, any(), any())
       idlingResource.operationFinished()
@@ -526,14 +524,14 @@ class PushFactoryTest {
   fun `Delete factor with API error should call error`() {
     val sid = "sid"
     val serviceSid = "ISbb7823aa5dcce90443f856406abd7000"
-    val entityId = "entityId"
+    val identity = "identity"
     val friendlyName = "factor name"
     val accountSid = "accountSid"
     val status = FactorStatus.Unverified
     val credentialSid = "credentialSid"
     val factor =
       PushFactor(
-          sid, friendlyName, accountSid, serviceSid, entityId, status, Date(), Config(credentialSid)
+          sid, friendlyName, accountSid, serviceSid, identity, status, Date(), Config(credentialSid)
       )
     whenever(factorProvider.get(sid)).thenReturn(factor)
     val expectedException: TwilioVerifyException = mock()

--- a/verify/src/test/java/com/twilio/verify/networking/AuthenticationProviderTest.kt
+++ b/verify/src/test/java/com/twilio/verify/networking/AuthenticationProviderTest.kt
@@ -42,12 +42,12 @@ class AuthenticationProviderTest {
     val friendlyName = "friendlyName"
     val accountSid = "accountSid"
     val serviceSid = "serviceSid"
-    val entityIdentity = "entityIdentity"
+    val identity = "identity"
     val credentialSid = "credentialSid"
     val status = FactorStatus.Unverified
     val factor =
       PushFactor(
-          factorSid, friendlyName, accountSid, serviceSid, entityIdentity, status, Date(),
+          factorSid, friendlyName, accountSid, serviceSid, identity, status, Date(),
           Config(credentialSid)
       ).apply {
         keyPairAlias = "test"
@@ -76,12 +76,12 @@ class AuthenticationProviderTest {
     val friendlyName = "friendlyName"
     val accountSid = "accountSid"
     val serviceSid = "serviceSid"
-    val entityIdentity = "entityIdentity"
+    val identity = "identity"
     val credentialSid = "credentialSid"
     val status = FactorStatus.Unverified
     val factor =
       PushFactor(
-          factorSid, friendlyName, accountSid, serviceSid, entityIdentity, status, Date(),
+          factorSid, friendlyName, accountSid, serviceSid, identity, status, Date(),
           Config(credentialSid)
       ).apply {
         keyPairAlias = null


### PR DESCRIPTION
Rename enrollment JWE to access token. 
Rename entity to identity.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
