### PR TITLE
fix: Delete factor should delete it locally for deleted factors from API [18910]

### DIFF
--- a/verify/src/androidTest/java/com/twilio/verify/BaseServerTest.kt
+++ b/verify/src/androidTest/java/com/twilio/verify/BaseServerTest.kt
@@ -83,7 +83,7 @@ open class BaseServerTest {
 }
 
 fun CountingIdlingResource.waitForResource(
-  waitFor: Long = 100,
+  waitFor: Long = 200,
   times: Int = 20
 ) {
   for (i in 0..times) {

--- a/verify/src/main/java/com/twilio/verify/api/BaseAPIClient.kt
+++ b/verify/src/main/java/com/twilio/verify/api/BaseAPIClient.kt
@@ -10,6 +10,7 @@ import com.twilio.verify.networking.NetworkException
  */
 
 internal const val unauthorized = 401
+internal const val notFound = 404
 internal const val dateHeaderKey = "Date"
 internal const val retryTimes = 1
 

--- a/verify/src/main/java/com/twilio/verify/api/FactorAPIClient.kt
+++ b/verify/src/main/java/com/twilio/verify/api/FactorAPIClient.kt
@@ -182,7 +182,16 @@ internal class FactorAPIClient(
             success()
           },
           { exception ->
-            validateException(exception, ::deleteFactor, retries, error)
+            when (exception.failureResponse?.responseCode) {
+              notFound -> success()
+              unauthorized ->
+                if (retries == 0) {
+                  success()
+                } else {
+                  validateException(exception, ::deleteFactor, retries, error)
+                }
+              else -> validateException(exception, ::deleteFactor, retries, error)
+            }
           }
         )
       } catch (e: TwilioVerifyException) {


### PR DESCRIPTION
* Delete factor should delete it locally for deleted factors from API

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
