### PR TITLE
ACCSEC-20380 Use maven local for new SDK version

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -122,11 +122,11 @@ platform :android do
       description: notes,
       commitish: "main"
     )
-    # TODO: Refactor this part to fetch the latest twilio-verify version from local e.g. MavenLocal
-    # plain_notes = conventional_changelog(
-    #         format: 'plain',
-    #         commit_url: 'https://github.com/twilio/twilio-verify-android/commit')
-    # distribute_sample_app(notes: plain_notes, build_type: "Release", url: ENV["PROD_URL"], versionName: next_version)
+    gradle(task: "publishTwilioVerifyPublicationToMavenLocal")
+    plain_notes = conventional_changelog(
+            format: 'plain',
+            commit_url: 'https://github.com/twilio/twilio-verify-android/commit')
+    distribute_sample_app(notes: plain_notes, build_type: "Release", url: ENV["PROD_URL"], versionName: next_version)
   end
 
   desc "Danger check"

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -23,6 +23,9 @@ plugins {
   id(Config.Plugins.firebasePerformance)
   jacoco
 }
+repositories {
+  mavenLocal()
+}
 
 val verifyVersionName: String by rootProject.allprojects.first { it.name == Modules.verify }.extra
 val verifyVersionCode: String by rootProject.allprojects.first { it.name == Modules.verify }.extra


### PR DESCRIPTION
<!-- Thanks for contributing to Twilio Verify. Please consider this template for your PR -->
<!-- Title format: [Ticket Number] - Brief description -->
<!-- Assignee: Please assign yourself to this PR -->
<!-- Labels: Please add proper labels accordingly (task, bug, housekeeping, etc) -->

<!-- Ticket: Please add the Jira ticket number or the Github issue number according to your case -->
## Jira Ticket
- ACCSEC-20380

<!-- Description: Please add a detailed description of your contribution. Include associated PRs or dependencies. If you're opening an integration PR, please add proper checklist of remaining items and tag this PR with a "DO NOT MERGE YET" -->
## Description
- Publish library to maven local, use it for final version after releasing a new SDK version