### PR TITLE
ACCSEC-21829 Creating tag after bumping version

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -103,8 +103,6 @@ platform :android do
       commit_url: 'https://github.com/twilio/twilio-verify-android/commit')
     tag = next_version
     UI.important(notes)
-    add_git_tag(tag: tag)
-    push_git_tags(tag: tag)
 
     UI.message("Updating CHANGELOG.md")
     sdk_size = sh("cat ../builds/sizeReport/TwilioVerifySizeImpactReport.txt")
@@ -113,6 +111,8 @@ platform :android do
     git_add(path: ["./verify/gradle.properties", "./CHANGELOG.md", "./docs/#{next_version}", "./docs/latest"])
     sh("git commit -m \"Version bump to #{next_version} [skip ci]\"")
     push_to_git_remote
+    add_git_tag(tag: tag)
+    push_git_tags(tag: tag)
 
     set_github_release(
       repository_name: "twilio/twilio-verify-android",


### PR DESCRIPTION
<!-- Thanks for contributing to Twilio Verify. Please consider this template for your PR -->
<!-- Title format: [Ticket Number] - Brief description -->
<!-- Assignee: Please assign yourself to this PR -->
<!-- Labels: Please add proper labels accordingly (task, bug, housekeeping, etc) -->

<!-- Ticket: Please add the Jira ticket number or the Github issue number according to your case -->
## Jira Ticket
- ACCSEC-21829

<!-- Description: Please add a detailed description of your contribution. Include associated PRs or dependencies. If you're opening an integration PR, please add proper checklist of remaining items and tag this PR with a "DO NOT MERGE YET" -->
## Description
- Move tag creation after bumping version

<!-- Commit message: This repository uses a commit message convention https://docs.google.com/document/d/19ed9FHIAlJwlGzf3xacgE15MVfTwx8n9G2QeYyCr-5E/edit?usp=drive_web&ouid=116864038767072405931 set the commit message to be used when merging this PR e.g. docs: add architecture diagrams [ACCSEC-99999] -->
## Commit message
- chore: Create tag after pushing new version