### PR TITLE
[ACCSEC-22770] Validate biometrics before repository

### DIFF
--- a/security/gradle.properties
+++ b/security/gradle.properties
@@ -1,5 +1,5 @@
 pomName=Twilio Security SDK for Android
 pomArtifactId=twilio-security-android
 # Increase version for verify library if needed (verify/build.gradle.kts)
-securityVersionName=0.0.8
-securityVersionCode=8000
+securityVersionName=0.0.9
+securityVersionCode=9000

--- a/security/src/main/java/com/twilio/security/storage/AuthenticatedEncryptedStorage.kt
+++ b/security/src/main/java/com/twilio/security/storage/AuthenticatedEncryptedStorage.kt
@@ -19,9 +19,7 @@ package com.twilio.security.storage
 import android.content.SharedPreferences
 import com.twilio.security.crypto.KeyManager
 import com.twilio.security.crypto.key.authentication.BiometricAuthenticator
-import com.twilio.security.crypto.key.template.AESGCMNoPaddingCipherTemplate
 import com.twilio.security.crypto.keyManager
-import com.twilio.security.storage.key.BiometricSecretKey
 import kotlin.reflect.KClass
 
 interface AuthenticatedEncryptedStorage {

--- a/security/src/main/java/com/twilio/security/storage/AuthenticatedEncryptedStorage.kt
+++ b/security/src/main/java/com/twilio/security/storage/AuthenticatedEncryptedStorage.kt
@@ -56,12 +56,5 @@ fun authenticatedEncryptedPreferences(
   storageAlias: String,
   sharedPreferences: SharedPreferences
 ): AuthenticatedEncryptedStorage {
-  val keyManager = keyManager()
-  val biometricSecretKey = BiometricSecretKey(
-    AESGCMNoPaddingCipherTemplate(storageAlias, authenticationRequired = true), keyManager
-  )
-  if (!keyManager.contains(storageAlias) && sharedPreferences.all.isEmpty()) {
-    biometricSecretKey.create()
-  }
-  return AuthenticatedEncryptedPreferences(sharedPreferences, storageAlias, keyManager, DefaultSerializer())
+  return AuthenticatedEncryptedPreferences(sharedPreferences, storageAlias, keyManager(), DefaultSerializer())
 }


### PR DESCRIPTION
## Ticket
- ACCSEC-22770

## Description
- Validate biometrics available before creating AppProtectionRepository
- Update security version name and code 

## Commit message
- fix: validate biometrics before repository

## Testing
- [ ] Added unit tests
- [X] Ran unit tests successfully
- [ ] Added documentation for public APIs and/or Wiki
